### PR TITLE
Allow both internal and external setting names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [Get public wiki settings from wiki/details endpoint](https://github.com/wbstack/api/pull/15)
 - [Migrate wiki_settings value column from string to text](https://github.com/wbstack/api/pull/16)
+- [Wiki settings API can now input either internal or external setting names](https://github.com/wbstack/api/pull/20)
 
 ## 6x-1.6 - 11 December 2020
 

--- a/app/Http/Controllers/WikiSettingController.php
+++ b/app/Http/Controllers/WikiSettingController.php
@@ -10,14 +10,16 @@ class WikiSettingController extends Controller
 {
 
     /**
-     * Keys are API setting names
-     * Values are mediawiki setting names
+     * An map of old setting names used externally to the internal names we now use.
+     * See normalizeSetting
+     * Use of the old names (the keys here) should be deprecated
+     * We can remove this once we update the UI to not used them any more.
      *
      * FIXME: this list probably also needs to be kept in sync with the one in Wiki.php model
      *
      * @var string[]
      */
-    static $settingMap = [
+    static $oldSettingMap = [
         'skin' => 'wgDefaultSkin',
         'extConfirmAccount' => 'wwExtEnableConfirmAccount',
         'wikibaseStringLengthString' => 'wwWikibaseStringLengthString',
@@ -26,27 +28,39 @@ class WikiSettingController extends Controller
         ];
 
     static $settingValidation = [
-        'skin' => 'string|in:vector,modern,timeless',
-        'extConfirmAccount' => 'boolean',
-        'wikibaseStringLengthString' => 'integer|between:400,2500',
-        'wikibaseStringLengthMonolingualText' => 'integer|between:400,2500',
-        'wikibaseStringLengthMultilang' => 'integer|between:250,2500',
+        'wgDefaultSkin' => 'string|in:vector,modern,timeless',
+        'wwExtEnableConfirmAccount' => 'boolean',
+        'wwWikibaseStringLengthString' => 'integer|between:400,2500',
+        'wwWikibaseStringLengthMonolingualText' => 'integer|between:400,2500',
+        'wwWikibaseStringLengthMultilang' => 'integer|between:250,2500',
     ];
+
+    /**
+     * Historically the setting names submitted to the API and actually stored were different.
+     * We want to standardize these to make things easier to work with.
+     * (especially now we are also retrieving these settings)
+     * So now accept both the old external names and internal names, but internally convert to the internal names.
+     */
+    private function normalizeSetting( $setting ) {
+        if ( array_key_exists( $setting, self::$oldSettingMap ) ) {
+            $setting = self::$oldSettingMap[$setting];
+        }
+        return $setting;
+    }
 
     public function update( $setting, Request $request)
     {
         $request->validate([
             'wiki' => 'required|numeric',
-            'setting' => 'required|string|in:' . implode( ',', array_keys( self::$settingMap ) ),
+            // Allow both internal and external setting names, see normalizeSetting
+            'setting' => 'required|string|in:' . implode( ',', array_merge( array_keys( self::$oldSettingMap ), self::$oldSettingMap ) ),
         ]);
-        $apiSetting = $request->input('setting');
+        $settingName = $this->normalizeSetting( $request->input('setting') );
 
-        // Only allow certain values
         $request->validate([
-            'value' => 'required' .( array_key_exists( $apiSetting, self::$settingValidation ) ? '|' . self::$settingValidation[$apiSetting] : '' ),
+            'value' => 'required' . ( array_key_exists( $settingName, self::$settingValidation ) ? '|' . self::$settingValidation[$settingName] : '' ),
         ]);
         $value = $request->input('value');
-
 
         $user = $request->user();
         $wikiId = $request->input('wiki');
@@ -59,11 +73,10 @@ class WikiSettingController extends Controller
             return response()->json('Unauthorized', 401);
         }
 
-
         WikiSetting::updateOrCreate(
             [
                 'wiki_id' => $wikiId,
-                'name' => self::$settingMap[$apiSetting],
+                'name' => $settingName,
             ],
             [
                 'value' => $value,

--- a/tests/Routes/Traits/PostRequestNeedAuthentication.php
+++ b/tests/Routes/Traits/PostRequestNeedAuthentication.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Tests\Routes\Traits;
+
+trait PostRequestNeedAuthentication
+{
+    public function testPostRequestWhenUnauthenticatedRespondes401()
+    {
+        $response = $this->json('POST', $this->route);
+        $this->assertEquals(401, $response->status());
+    }
+}

--- a/tests/Routes/Wiki/SettingUpdateTest.php
+++ b/tests/Routes/Wiki/SettingUpdateTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Routes\Wiki\Managers;
+
+use Tests\TestCase;
+use Tests\Routes\Traits\OptionsRequestAllowed;
+use Tests\Routes\Traits\PostRequestNeedAuthentication;
+
+class SettingUpdateTest extends TestCase
+{
+    protected $route = 'wiki/setting/foo/update';
+
+    use OptionsRequestAllowed;
+    use PostRequestNeedAuthentication;
+}


### PR DESCRIPTION
This refactoring will allow us to migrate to a single set of setting names instead of 2.
This is more relevant now the API is also exposing the setting names being returned.
Maintaining the mapping will be painful and pointless.