### PR TITLE
Use public storage instead of  gcs-public-static for development

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -1,6 +1,6 @@
 <?php
 
-return [
+$fileSystems = [
 
     /*
     |--------------------------------------------------------------------------
@@ -78,3 +78,9 @@ return [
     ],
 
 ];
+
+if (env('APP_ENV') === 'local') {
+    $fileSystems['disks']['gcs-public-static'] = $fileSystems['disks']['public'];
+}
+
+return $fileSystems;


### PR DESCRIPTION
fixes #37

This swaps out the GCS `gcs-public-static` disk for the default public file storage during development. ~~It sort of fixes some problems with #37 except that the URLs are generated somewhat incorrectly because it's not aware of running in a docker container.~~ It requires `APP_URL` to be configured properly in `.env`. `APP_URL=http://localhost:8082` most likely.