### PR TITLE
Mass dependabot github action bumps 30th June

### DIFF
--- a/.github/workflows/composer.test.yml
+++ b/.github/workflows/composer.test.yml
@@ -27,7 +27,7 @@ jobs:
       run: docker-compose up -d
 
     - name: Setup - Keep trying to install the DBs (try for 30 seconds)
-      uses: nick-invision/retry@v2.4.0
+      uses: nick-invision/retry@v2.4.1
       with:
         max_attempts: 30
         retry_wait_seconds: 1

--- a/.github/workflows/composer.test.yml
+++ b/.github/workflows/composer.test.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@master
 
     - name: Install dependencies
-      uses: php-actions/composer@v5
+      uses: php-actions/composer@v6
       with:
         php_version: 7.4
         command: install

--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -45,7 +45,7 @@ jobs:
           password: ${{ secrets.CR_PAT }}
       -
         name: Build and push
-        uses: docker/build-push-action@v2.4.0
+        uses: docker/build-push-action@v2.5.0
         with:
           context: .
           file: ./Dockerfile

--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -18,7 +18,7 @@ jobs:
       -
         name: Docker meta
         id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v3.1.0
+        uses: crazy-max/ghaction-docker-meta@v3.3.0
         with:
           images: ghcr.io/${{ github.repository }}
       -

--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-buildx-
       -
         name: Login to GitHub Container Registry
-        uses: docker/login-action@v1.9.0
+        uses: docker/login-action@v1.10.0
         if: github.event_name != 'pull_request'
         with:
           registry: ghcr.io

--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -29,7 +29,7 @@ jobs:
         uses: docker/setup-buildx-action@v1.3.0
       -
         name: Cache Docker layers
-        uses: actions/cache@v2.1.5
+        uses: actions/cache@v2.1.6
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/docker.build.yml
+++ b/.github/workflows/docker.build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: docker/setup-qemu-action@v1
       -
         name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1.3.0
+        uses: docker/setup-buildx-action@v1.4.1
       -
         name: Cache Docker layers
         uses: actions/cache@v2.1.6


### PR DESCRIPTION
- Bump crazy-max/ghaction-docker-meta from 3.1.0 to 3.3.0
- Bump docker/build-push-action from 2.4.0 to 2.5.0
- Bump actions/cache from 2.1.5 to 2.1.6
- Bump php-actions/composer from 5 to 6
- Bump nick-invision/retry from 2.4.0 to 2.4.1
- Bump docker/login-action from 1.9.0 to 1.10.0
- Bump docker/setup-buildx-action from 1.3.0 to 1.4.1
