### PR TITLE
[ELASTICSEARCH-FIRST] Enable Elasticsearch for new wikis

### DIFF
--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -80,7 +80,7 @@ class WikiController extends Controller
                 'value' => Str::random(64),
             ]);
 
-            // Create elasticsearch setting to be updated once ElasticSearch has been initialized
+            // Create the enabled elasticsearch setting
             // T285541
             WikiSetting::create([
                 'wiki_id' => $wiki->id,

--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -118,7 +118,7 @@ class WikiController extends Controller
         $this->dispatch(new ProvisionQueryserviceNamespaceJob(null, 10));
 
         // dispatch elasticsearch init job to enable the feature
-        $this->dispatch(new ElasticSearchIndexInit($wiki->domain, $wiki->id));
+        $this->dispatch(new ElasticSearchIndexInit($wiki->id));
 
         $res['success'] = true;
         $res['message'] = 'Success!';

--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -80,13 +80,13 @@ class WikiController extends Controller
                 'value' => Str::random(64),
             ]);
 
-            // Enable elasticsearch for new wikis by default
+            // Create elasticsearch setting to be updated once ElasticSearch has been initialized
             // T285541
-//             WikiSetting::create([
-//                 'wiki_id' => $wiki->id,
-//                 'name' => 'wwExtEnableElasticSearch',
-//                 'value' => true,
-//             ]);
+            WikiSetting::create([
+                'wiki_id' => $wiki->id,
+                'name' => 'wwExtEnableElasticSearch',
+                'value' => false,
+            ]);
 
             // Also track the domain forever in your domains table
             $wikiDomain = WikiDomain::create([
@@ -117,7 +117,8 @@ class WikiController extends Controller
         $this->dispatch(new ProvisionWikiDbJob(null, null, 10));
         $this->dispatch(new ProvisionQueryserviceNamespaceJob(null, 10));
 
-//        $this->dispatch(new ElasticSearchIndexInit($wiki->domain));
+        // dispatch elasticsearch init job to enable the feature
+        $this->dispatch(new ElasticSearchIndexInit($wiki->domain, $wiki->id));
 
         $res['success'] = true;
         $res['message'] = 'Success!';

--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -76,7 +76,7 @@ class WikiController extends Controller
             // Docs: https://www.mediawiki.org/wiki/Manual:$wgSecretKey
             WikiSetting::create([
                 'wiki_id' => $wiki->id,
-                'name' => 'wgSecretKey',
+                'name' => WikiSetting::wgSecretKey,
                 'value' => Str::random(64),
             ]);
 
@@ -84,8 +84,8 @@ class WikiController extends Controller
             // T285541
             WikiSetting::create([
                 'wiki_id' => $wiki->id,
-                'name' => 'wwExtEnableElasticSearch',
-                'value' => false,
+                'name' => WikiSetting::wwExtEnableElasticSearch,
+                'value' => true,
             ]);
 
             // Also track the domain forever in your domains table

--- a/app/Jobs/ElasticSearchIndexInit.php
+++ b/app/Jobs/ElasticSearchIndexInit.php
@@ -6,20 +6,18 @@ use App\WikiSetting;
 use App\Http\Curl\CurlRequest;
 use App\Http\Curl\HttpRequest;
 use Illuminate\Support\Facades\Log;
+use App\Wiki;
 
 class ElasticSearchIndexInit extends Job implements ShouldBeUnique
 {
-    private $wikiDomain;
     private $wikiId;
-
     private $request;
 
     /**
      * @return void
      */
-    public function __construct( string $wikiDomain, int $wikiId, HttpRequest $request = null )
+    public function __construct( int $wikiId, HttpRequest $request = null )
     {
-        $this->wikiDomain = $wikiDomain;
         $this->wikiId = $wikiId;
         $this->request = $request ?? new CurlRequest();
     }
@@ -31,7 +29,7 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
      */
     public function uniqueId()
     {
-        return $this->wikiDomain;
+        return strval($this->wikiId);
     }
 
     /**
@@ -39,14 +37,26 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
      */
     public function handle()
     {
-        $setting = WikiSetting::where([ 'wiki_id' => $this->wikiId, 'name' => WikiSetting::wwExtEnableElasticSearch, ])->first();
+        $wiki = Wiki::whereId( $this->wikiId )->with('settings')->with('wikiDb')->first();
 
-        // job got triggered but no setting in database
-        if ( $setting === null ) {
-            $this->fail(
-                new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiDomain.' was triggered but not setting available.')
-            );
+        // job got triggered but no wiki
+        if ( !$wiki ) {
+            $this->fail( new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiId.' was triggered but not wiki available.') );
+            return;
+        }
 
+        $setting = $wiki->settings()->where([ 'name' => WikiSetting::wwExtEnableElasticSearch, ])->first();
+        // job got triggered but no setting
+        if ( !$setting ) {
+            $this->fail( new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiId.' was triggered but not setting available') );
+            return;
+        }
+
+        $wikiDB = $wiki->wikiDb()->first();
+        // no wikiDB around
+        if ( !$wikiDB ) {
+            $this->fail( new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiId.' was triggered but not WikiDb available') );
+            $setting->update( [  'value' => false  ] );
             return;
         }
         
@@ -55,12 +65,12 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
                 CURLOPT_URL => getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=wbstackElasticSearchInit&format=json',
                 CURLOPT_RETURNTRANSFER => true,
                 CURLOPT_ENCODING => '',
-                CURLOPT_TIMEOUT => 10,
+                CURLOPT_TIMEOUT => 60, // This could potentially take a bit longer
                 CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
                 CURLOPT_CUSTOMREQUEST => 'POST',
                 CURLOPT_HTTPHEADER => [
                     'content-type: application/x-www-form-urlencoded',
-                    'host: '.$this->wikiDomain,
+                    'host: '.$wiki->domain,
                 ]
             ]
         );
@@ -69,10 +79,8 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
         $err = $this->request->error();
 
         if ($err) {
-            $this->fail(
-                new \RuntimeException('curl error for '.$this->wikiDomain.': '.$err)
-            );
-
+            $this->fail( new \RuntimeException('curl error for '.$this->wikiId.': '.$err) );
+            $setting->update( [  'value' => false  ] );
             return;
         }
 
@@ -81,50 +89,39 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
         $response = json_decode($rawResponse, true);
 
         if (!array_key_exists('wbstackElasticSearchInit', $response)) {
-            $this->fail(
-                new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiDomain.'. No wbstackElasticSearchInit key in response: '.$rawResponse)
-            );
-
+            $this->fail( new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiId.'. No wbstackElasticSearchInit key in response: '.$rawResponse) );
+            $setting->update( [  'value' => false  ] );
             return;
         }
 
         if ($response['wbstackElasticSearchInit']['success'] == 0) {
-            $this->fail(
-                new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiDomain.' was not successful:'.$rawResponse)
-            );
-
+            $this->fail( new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiId.' was not successful:'.$rawResponse) );
+            $setting->update( [  'value' => false  ] );
             return;
         }
 
         $output = $response['wbstackElasticSearchInit']['output'];
 
-        $newlyCreated = "\tCreating index...ok"; // occurs a couple of times when newly created
-        $updated = "\t\tValidating {$this->wikiDomain}_general alias...ok"; // occurs on a successful update run
-
         $enableElasticSearchFeature = false;
 
-        if ( in_array( $newlyCreated,  $output ) ) {
+        // occurs a couple of times when newly created
+        if ( in_array( "\tCreating index...ok",  $output ) ) {
 
             // newly created index succeeded, turn on the wiki setting
             $enableElasticSearchFeature = true;
 
-        } else if ( in_array( $updated, $output ) ) {
+        // occurs on a successful update run
+        } else if ( in_array( "\t\tValidating {$wikiDB->name}_general alias...ok", $output ) ) {
 
             // script ran and update was successful, make sure feature is enabled
             $enableElasticSearchFeature = true;
-        }else {
+        } else {
 
             Log::error(__METHOD__ . ": Job finished but didn't create or update, something is weird");
-            $this->fail(
-                new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiDomain.' was not successful:'.$rawResponse)
-            );
+            $this->fail( new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiId.' was not successful:' . $rawResponse ) );
         }
 
-        $setting->update(
-            [ 
-                'value' => $enableElasticSearchFeature 
-            ]
-        );
+        $setting->update( [  'value' => $enableElasticSearchFeature  ] );
 
     }
 }

--- a/app/Jobs/ElasticSearchIndexInit.php
+++ b/app/Jobs/ElasticSearchIndexInit.php
@@ -1,8 +1,9 @@
 <?php
 
 namespace App\Jobs;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 
-class ElasticSearchIndexInit extends Job
+class ElasticSearchIndexInit extends Job implements ShouldBeUnique
 {
     private $wikiDomain;
 
@@ -12,6 +13,16 @@ class ElasticSearchIndexInit extends Job
     public function __construct($wikiDomain)
     {
         $this->wikiDomain = $wikiDomain;
+    }
+
+    /**
+     * The unique ID of the job.
+     *
+     * @return string
+     */
+    public function uniqueId()
+    {
+        return $this->wikiDomain;
     }
 
     /**

--- a/app/Jobs/ElasticSearchIndexInit.php
+++ b/app/Jobs/ElasticSearchIndexInit.php
@@ -2,17 +2,26 @@
 
 namespace App\Jobs;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use App\WikiSetting;
+use App\Http\Curl\CurlRequest;
+use App\Http\Curl\HttpRequest;
+use Illuminate\Support\Facades\Log;
 
 class ElasticSearchIndexInit extends Job implements ShouldBeUnique
 {
     private $wikiDomain;
+    private $wikiId;
+
+    private $request;
 
     /**
      * @return void
      */
-    public function __construct($wikiDomain)
+    public function __construct( string $wikiDomain, int $wikiId, HttpRequest $request = null )
     {
         $this->wikiDomain = $wikiDomain;
+        $this->wikiId = $wikiId;
+        $this->request = $request ?? new CurlRequest();
     }
 
     /**
@@ -30,31 +39,44 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
      */
     public function handle()
     {
-        $curl = curl_init();
-        curl_setopt_array($curl, [
-            CURLOPT_URL => getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=wbstackElasticSearchInit&format=json',
-            CURLOPT_RETURNTRANSFER => true,
-            CURLOPT_ENCODING => '',
-            CURLOPT_TIMEOUT => 10,
-            CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-            CURLOPT_CUSTOMREQUEST => 'POST',
-            CURLOPT_HTTPHEADER => [
-                'content-type: application/x-www-form-urlencoded',
-                'host: '.$this->wikiDomain,
-            ],
-        ]);
+        $setting = WikiSetting::where([ 'wiki_id' => $this->wikiId, 'name' => WikiSetting::wwExtEnableElasticSearch, ])->first();
 
-        $rawResponse = curl_exec($curl);
-        $err = curl_error($curl);
+        // job got triggered but no setting in database
+        if ( $setting === null ) {
+            $this->fail(
+                new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiDomain.' was triggered but not setting available.')
+            );
+
+            return;
+        }
+        
+        $this->request->setOptions( 
+            [
+                CURLOPT_URL => getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=wbstackElasticSearchInit&format=json',
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_ENCODING => '',
+                CURLOPT_TIMEOUT => 10,
+                CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+                CURLOPT_CUSTOMREQUEST => 'POST',
+                CURLOPT_HTTPHEADER => [
+                    'content-type: application/x-www-form-urlencoded',
+                    'host: '.$this->wikiDomain,
+                ]
+            ]
+        );
+
+        $rawResponse = $this->request->execute();
+        $err = $this->request->error();
+
         if ($err) {
             $this->fail(
                 new \RuntimeException('curl error for '.$this->wikiDomain.': '.$err)
             );
 
-            return; //safegaurd
+            return;
         }
 
-        curl_close($curl);
+        $this->request->close();
 
         $response = json_decode($rawResponse, true);
 
@@ -63,7 +85,7 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
                 new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiDomain.'. No wbstackElasticSearchInit key in response: '.$rawResponse)
             );
 
-            return; //safegaurd
+            return;
         }
 
         if ($response['wbstackElasticSearchInit']['success'] == 0) {
@@ -71,7 +93,38 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
                 new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiDomain.' was not successful:'.$rawResponse)
             );
 
-            return; //safegaurd
+            return;
         }
+
+        $output = $response['wbstackElasticSearchInit']['output'];
+
+        $newlyCreated = "\tCreating index...ok"; // occurs a couple of times when newly created
+        $updated = "\t\tValidating {$this->wikiDomain}_general alias...ok"; // occurs on a successful update run
+
+        $enableElasticSearchFeature = false;
+
+        if ( in_array( $newlyCreated,  $output ) ) {
+
+            // newly created index succeeded, turn on the wiki setting
+            $enableElasticSearchFeature = true;
+
+        } else if ( in_array( $updated, $output ) ) {
+
+            // script ran and update was successful, make sure feature is enabled
+            $enableElasticSearchFeature = true;
+        }else {
+
+            Log::error(__METHOD__ . ": Job finished but didn't create or update, something is weird");
+            $this->fail(
+                new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiDomain.' was not successful:'.$rawResponse)
+            );
+        }
+
+        $setting->update(
+            [ 
+                'value' => $enableElasticSearchFeature 
+            ]
+        );
+
     }
 }

--- a/app/WikiDb.php
+++ b/app/WikiDb.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 /**
  * App\WikiDb.
@@ -33,6 +34,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class WikiDb extends Model
 {
+    use HasFactory;
+
     /**
      * The attributes that are mass assignable.
      *

--- a/app/WikiSetting.php
+++ b/app/WikiSetting.php
@@ -3,6 +3,7 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 
 /**
  * App\WikiSetting.
@@ -27,6 +28,11 @@ use Illuminate\Database\Eloquent\Model;
  */
 class WikiSetting extends Model
 {
+    use HasFactory;
+
+    public const wwExtEnableElasticSearch = 'wwExtEnableElasticSearch';
+    public const wwExtEnableWikibaseLexeme = 'wwExtEnableWikibaseLexeme';
+
     /**
      * The attributes that are mass assignable.
      *

--- a/app/WikiSetting.php
+++ b/app/WikiSetting.php
@@ -32,6 +32,7 @@ class WikiSetting extends Model
 
     public const wwExtEnableElasticSearch = 'wwExtEnableElasticSearch';
     public const wwExtEnableWikibaseLexeme = 'wwExtEnableWikibaseLexeme';
+    public const wgSecretKey = 'wgSecretKey';
 
     /**
      * The attributes that are mass assignable.

--- a/database/factories/WikiDbFactory.php
+++ b/database/factories/WikiDbFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+use App\WikiDb;
+
+class WikiDbFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = WikiDb::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [
+            'name' => $this->faker->text(5),
+            'prefix' => $this->faker->text(5),
+            'user' => 'root',
+            'password' => 'toor',
+            'version' => 'seeded'
+        ];
+    }
+}

--- a/database/factories/WikiFactory.php
+++ b/database/factories/WikiFactory.php
@@ -23,8 +23,7 @@ class WikiFactory extends Factory
     {
         return [
             'sitename' => $this->faker->text(5),
-            'domain' => $this->faker->domainName,
-            'deleted_at' => $this->faker->dateTime
+            'domain' => $this->faker->domainName
         ];
     }
 }

--- a/database/factories/WikiSettingFactory.php
+++ b/database/factories/WikiSettingFactory.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Database\Factories;
+
+use App\WikiSetting;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class WikiSettingFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = WikiSetting::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array
+     */
+    public function definition()
+    {
+        return [];
+    }
+}

--- a/tests/Jobs/ElasticSearchIndexInitTest.php
+++ b/tests/Jobs/ElasticSearchIndexInitTest.php
@@ -10,12 +10,15 @@ use App\Http\Curl\HttpRequest;
 use App\WikiManager;
 use App\WikiSetting;
 use App\Wiki;
+use Illuminate\Contracts\Queue\Job;
+use App\WikiDb;
 
 class ElasticSearchIndexInitTest extends TestCase
 {
     use DatabaseTransactions;
 
     private $wiki;
+    private $wikiDb;
     private $user;
 
     public function setUp(): void {
@@ -28,9 +31,12 @@ class ElasticSearchIndexInitTest extends TestCase
             [
                 'wiki_id' => $this->wiki->id,
                 'name' => WikiSetting::wwExtEnableElasticSearch,
-                'value' => false
+                'value' => true
             ]
         );
+        $this->wikiDb = WikiDb::factory()->create([
+            'wiki_id' => $this->wiki->id
+        ]);
     }
 
     public function testSuccess()
@@ -47,7 +53,13 @@ class ElasticSearchIndexInitTest extends TestCase
         $request = $this->createMock(HttpRequest::class);
         $request->method('execute')->willReturn(json_encode($mockResponse));
 
-        $job = new ElasticSearchIndexInit($this->wiki->domain, $this->wiki->id, $request);
+        $mockJob = $this->createMock(Job::class);
+        $mockJob->expects($this->never())
+                ->method('fail')
+                ->withAnyParameters();
+
+        $job = new ElasticSearchIndexInit($this->wiki->id, $request);
+        $job->setJob($mockJob);
         $job->handle();
 
         // feature should get enabled
@@ -64,41 +76,25 @@ class ElasticSearchIndexInitTest extends TestCase
             'wbstackElasticSearchInit' => [
                 "success" => 1,
                 "output" => [
-                    "\t\tValidating {$this->wiki->domain}_general alias...ok"
+                    "\t\tValidating {$this->wikiDb->name}_general alias...ok"
                 ]
             ]
         ];
         $request = $this->createMock(HttpRequest::class);
         $request->method('execute')->willReturn(json_encode($mockResponse));
 
-        $job = new ElasticSearchIndexInit($this->wiki->domain, $this->wiki->id, $request);
+        $mockJob = $this->createMock(Job::class);
+        $mockJob->expects($this->never())
+                ->method('fail')
+                ->withAnyParameters();
+
+        $job = new ElasticSearchIndexInit($this->wiki->id, $request);
+        $job->setJob($mockJob);
         $job->handle();
 
         // feature should get enabled
         $this->assertSame(
              1, 
-             WikiSetting::where( ['wiki_id' => $this->wiki->id, 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => true])->count()
-        );
-    }
-
-    public function testFailure()
-    {
-        $mockResponse = [
-            'warnings' => [],
-            'wbstackElasticSearchInit' => [
-                "success" => 0,
-                "output" => []
-            ]
-        ];
-        $request = $this->createMock(HttpRequest::class);
-        $request->method('execute')->willReturn(json_encode($mockResponse));
-
-        $job = new ElasticSearchIndexInit($this->wiki->domain, $this->wiki->id, $request);
-        $job->handle();
-
-        // feature should not get enabled
-        $this->assertSame(
-             0, 
              WikiSetting::where( ['wiki_id' => $this->wiki->id, 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => true])->count()
         );
     }
@@ -109,7 +105,72 @@ class ElasticSearchIndexInitTest extends TestCase
         $request = $this->createMock(HttpRequest::class);
         $request->expects( $this->never() )->method('execute');
 
-        $job = new ElasticSearchIndexInit($this->wiki->domain, $this->wiki->id, $request);
+        $job = new ElasticSearchIndexInit($this->wiki->id, $request);
         $job->handle();
     }
+
+    /**
+	 * @dataProvider failureProvider
+	 */
+    public function testFailure( $request, string $expectedFailure, $mockResponse )
+    {
+
+        $mockJob = $this->createMock(Job::class);
+        $mockJob->expects($this->once())
+                ->method('fail')
+                ->with(new \RuntimeException(str_replace('<WIKI_ID>', $this->wiki->id, $expectedFailure)));
+                
+        $request->method('execute')->willReturn(json_encode($mockResponse));
+
+        $job = new ElasticSearchIndexInit($this->wiki->id, $request);
+        $job->setJob($mockJob);
+        $job->handle();
+        
+
+        $this->assertSame(
+             0, 
+             WikiSetting::where( ['wiki_id' => $this->wiki->id, 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => true])->count()
+        );
+    }
+
+    public function failureProvider() {
+
+        $mockResponse = [];
+        yield [
+            $this->createMock(HttpRequest::class),
+            'wbstackElasticSearchInit call for <WIKI_ID>. No wbstackElasticSearchInit key in response: []',
+            $mockResponse
+        ];
+
+        $mockResponse = [
+            'warnings' => [],
+            'wbstackElasticSearchInit' => [
+                "success" => 0,
+                "output" => []
+            ]
+        ];
+
+        yield [
+            $this->createMock(HttpRequest::class),
+            'wbstackElasticSearchInit call for <WIKI_ID> was not successful:{"warnings":[],"wbstackElasticSearchInit":{"success":0,"output":[]}}',
+            $mockResponse
+        ];
+
+        $curlError = $this->createMock(HttpRequest::class);
+        $curlError->method('error')->willReturn('Scary Error!');
+        yield [
+            $curlError,
+            'curl error for <WIKI_ID>: Scary Error!',
+            $mockResponse
+        ];
+
+        $mockResponse['wbstackElasticSearchInit']['success'] = 1;
+        yield [
+            $this->createMock(HttpRequest::class),
+            'wbstackElasticSearchInit call for <WIKI_ID> was not successful:{"warnings":[],"wbstackElasticSearchInit":{"success":1,"output":[]}}',
+            $mockResponse
+        ];
+
+    }
+
 }

--- a/tests/Jobs/ElasticSearchIndexInitTest.php
+++ b/tests/Jobs/ElasticSearchIndexInitTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Tests\Jobs;
+
+use App\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use App\Jobs\ElasticSearchIndexInit;
+use App\Http\Curl\HttpRequest;
+use App\WikiManager;
+use App\WikiSetting;
+use App\Wiki;
+
+class ElasticSearchIndexInitTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private $wiki;
+    private $user;
+
+    public function setUp(): void {
+        parent::setUp();
+
+        $this->user = User::factory()->create(['verified' => true]);
+        $this->wiki = Wiki::factory()->create();
+        WikiManager::factory()->create(['wiki_id' => $this->wiki->id, 'user_id' => $this->user->id]);
+        WikiSetting::factory()->create(
+            [
+                'wiki_id' => $this->wiki->id,
+                'name' => WikiSetting::wwExtEnableElasticSearch,
+                'value' => false
+            ]
+        );
+    }
+
+    public function testSuccess()
+    {
+        $mockResponse = [
+            'warnings' => [],
+            'wbstackElasticSearchInit' => [
+                "success" => 1,
+                "output" => [
+                    "\tCreating index...ok" // successfully created some index
+                ]
+            ]
+        ];
+        $request = $this->createMock(HttpRequest::class);
+        $request->method('execute')->willReturn(json_encode($mockResponse));
+
+        $job = new ElasticSearchIndexInit($this->wiki->domain, $this->wiki->id, $request);
+        $job->handle();
+
+        // feature should get enabled
+        $this->assertSame(
+             1, 
+             WikiSetting::where( ['wiki_id' => $this->wiki->id, 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => true])->count()
+        );
+    }
+
+    public function testUpdate()
+    {
+        $mockResponse = [
+            'warnings' => [],
+            'wbstackElasticSearchInit' => [
+                "success" => 1,
+                "output" => [
+                    "\t\tValidating {$this->wiki->domain}_general alias...ok"
+                ]
+            ]
+        ];
+        $request = $this->createMock(HttpRequest::class);
+        $request->method('execute')->willReturn(json_encode($mockResponse));
+
+        $job = new ElasticSearchIndexInit($this->wiki->domain, $this->wiki->id, $request);
+        $job->handle();
+
+        // feature should get enabled
+        $this->assertSame(
+             1, 
+             WikiSetting::where( ['wiki_id' => $this->wiki->id, 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => true])->count()
+        );
+    }
+
+    public function testFailure()
+    {
+        $mockResponse = [
+            'warnings' => [],
+            'wbstackElasticSearchInit' => [
+                "success" => 0,
+                "output" => []
+            ]
+        ];
+        $request = $this->createMock(HttpRequest::class);
+        $request->method('execute')->willReturn(json_encode($mockResponse));
+
+        $job = new ElasticSearchIndexInit($this->wiki->domain, $this->wiki->id, $request);
+        $job->handle();
+
+        // feature should not get enabled
+        $this->assertSame(
+             0, 
+             WikiSetting::where( ['wiki_id' => $this->wiki->id, 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => true])->count()
+        );
+    }
+
+    public function testJobTriggeredButNoSetting()
+    {
+        WikiSetting::where( ['wiki_id' => $this->wiki->id, 'name' => WikiSetting::wwExtEnableElasticSearch ])->first()->delete();
+        $request = $this->createMock(HttpRequest::class);
+        $request->expects( $this->never() )->method('execute');
+
+        $job = new ElasticSearchIndexInit($this->wiki->domain, $this->wiki->id, $request);
+        $job->handle();
+    }
+}

--- a/tests/Routes/Wiki/CreateTest.php
+++ b/tests/Routes/Wiki/CreateTest.php
@@ -53,10 +53,9 @@ class CreateTest extends TestCase
             WikiSetting::where( [ 'name' => WikiSetting::wgSecretKey, 'wiki_id' => $id ] )->count()
         );
 
-        // will get flipped by the job
         $this->assertSame(
             1, 
-            WikiSetting::where( [ 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => false, 'wiki_id' => $id ] )->count()
+            WikiSetting::where( [ 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => true, 'wiki_id' => $id ] )->count()
         );
 
 

--- a/tests/Routes/Wiki/CreateTest.php
+++ b/tests/Routes/Wiki/CreateTest.php
@@ -4,10 +4,61 @@ namespace Tests\Routes\Wiki\Managers;
 
 use Tests\Routes\Traits\OptionsRequestAllowed;
 use Tests\TestCase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use App\User;
+use Illuminate\Support\Facades\Queue;
+use App\Jobs\ElasticSearchIndexInit;
+use App\Jobs\ProvisionWikiDbJob;
+use App\Jobs\MediawikiInit;
+use App\WikiSetting;
 
 class CreateTest extends TestCase
 {
     protected $route = 'wiki/create';
 
     use OptionsRequestAllowed;
+    use DatabaseTransactions;
+
+    public function testWikiCreateDispatchesSomeJobs()
+    {
+        Queue::fake();
+
+        $user = User::factory()->create(['verified' => true]);
+        Queue::assertNothingPushed();
+
+        $response = $this->actingAs($user, 'api')
+        ->json(
+            'POST', 
+            $this->route, 
+            [
+                'domain' => 'derp.com',
+                'sitename' => 'merp',
+                'username' => 'AdminBoss'
+            ]
+        );
+
+        $response->assertStatus(200)
+            ->assertJsonPath('data.domain', 'derp.com')
+            ->assertJsonPath('data.name', null)
+            ->assertJsonPath('success', true );
+
+        Queue::assertPushed( ProvisionWikiDbJob::class, 1);
+        Queue::assertPushed( MediawikiInit::class, 1);
+        Queue::assertPushed( ElasticSearchIndexInit::class, 1);
+        
+        $id = $response->original['data']['id'];
+
+        $this->assertSame(
+            1, 
+            WikiSetting::where( [ 'name' => WikiSetting::wgSecretKey, 'wiki_id' => $id ] )->count()
+        );
+
+        // will get flipped by the job
+        $this->assertSame(
+            1, 
+            WikiSetting::where( [ 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => false, 'wiki_id' => $id ] )->count()
+        );
+
+
+    }
 }


### PR DESCRIPTION
This enables elasticsearch for new wikis through the ElasticSearchIndexInit job.

Lexemes and Items end up in the same index so no special treatment should be needed when this setting is enabled but probably needs https://github.com/wbstack/mediawiki/pull/121 to be deployed before.