### PR TITLE
MediawikiInit Increase timeout to 60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # api
 
+## 8x.1.3 - 2 September 2021
+
+- [MediawikiInit job timeout increase (10-60 seconds)](https://github.com/wbstack/api/pull/180)
+
 ## 8x.1.2 - 2 September 2021
+
+Broken https://github.com/wbstack/api/issues/181
 
 - [Laravel 8.5.1 to 8.5.2](https://github.com/wbstack/api/pull/140)
 - [Enable elastic search on new wikis (calling `wbstackElasticSearchInit` on creation)](https://github.com/wbstack/api/pull/147)

--- a/app/Jobs/MediawikiInit.php
+++ b/app/Jobs/MediawikiInit.php
@@ -33,7 +33,7 @@ class MediawikiInit extends Job
             CURLOPT_URL => getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=wbstackInit&format=json',
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_ENCODING => '',
-            CURLOPT_TIMEOUT => 10,
+            CURLOPT_TIMEOUT => 60,
             CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
             CURLOPT_CUSTOMREQUEST => 'POST',
             CURLOPT_POSTFIELDS => http_build_query($data),


### PR DESCRIPTION
Seemingly this succeeds always, but the job can sometimes fail due to timeout
At some point we might want to tune the timeout more
But let's just make the errors / fails go away for now :)