### PR TITLE
Inject CurlRequest in handle on ElasticSearchIndexInit

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,9 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Http\Curl\CurlRequest;
+use App\Http\Curl\HttpRequest;
+use App\Jobs\ElasticSearchIndexInit;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -17,6 +20,9 @@ class AppServiceProvider extends ServiceProvider
         if ($this->app->environment() !== 'production') {
             $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
         }
+
+        $this->app->bind(HttpRequest::class, CurlRequest::class);
+
     }
 
     /**


### PR DESCRIPTION
Jobs apparently don't inject dependencies through the constructor but
rather the handle function. In case of an interface being used this will
also require a explicit binding in the app service provider.

This changes that, and adds a test to try this out.