### PR TITLE
ApiWbStackElasticSearchInit does not contain success

### DIFF
--- a/app/Jobs/ElasticSearchIndexInit.php
+++ b/app/Jobs/ElasticSearchIndexInit.php
@@ -92,7 +92,7 @@ class ElasticSearchIndexInit extends Job implements ShouldBeUnique
             return;
         }
 
-        if ( !array_key_exists('success', $response['wbstackElasticSearchInit']) || $response['wbstackElasticSearchInit']['success'] == 0) {
+        if ( !array_key_exists('return', $response['wbstackElasticSearchInit']) || $response['wbstackElasticSearchInit']['return'] !== 0) {
             $this->fail( new \RuntimeException('wbstackElasticSearchInit call for '.$this->wikiId.' was not successful:'.$rawResponse) );
             $setting->update( [  'value' => false  ] );
             return;

--- a/tests/Jobs/ElasticSearchIndexInitTest.php
+++ b/tests/Jobs/ElasticSearchIndexInitTest.php
@@ -58,7 +58,7 @@ class ElasticSearchIndexInitTest extends TestCase
         $mockResponse = [
             'warnings' => [],
             'wbstackElasticSearchInit' => [
-                "success" => 1,
+                "return" => 0,
                 "output" => [
                     '\tCreating index...ok' // successfully created some index
                 ]
@@ -105,7 +105,7 @@ class ElasticSearchIndexInitTest extends TestCase
         $mockResponse = [
             'warnings' => [],
             'wbstackElasticSearchInit' => [
-                "success" => 1,
+                "return" => 0,
                 "output" => [
                     '\t\tValidating ' . $this->wikiDb->name . '_general alias...ok'
                 ]
@@ -176,14 +176,14 @@ class ElasticSearchIndexInitTest extends TestCase
         $mockResponse = [
             'warnings' => [],
             'wbstackElasticSearchInit' => [
-                "success" => 0,
+                "return" => 0,
                 "output" => []
             ]
         ];
 
         yield [
             $this->createMock(HttpRequest::class),
-            'wbstackElasticSearchInit call for <WIKI_ID> was not successful:{"warnings":[],"wbstackElasticSearchInit":{"success":0,"output":[]}}',
+            'wbstackElasticSearchInit call for <WIKI_ID> was not successful:{"warnings":[],"wbstackElasticSearchInit":{"return":0,"output":[]}}',
             $mockResponse
         ];
 
@@ -195,10 +195,10 @@ class ElasticSearchIndexInitTest extends TestCase
             $mockResponse
         ];
 
-        $mockResponse['wbstackElasticSearchInit']['success'] = 1;
+        $mockResponse['wbstackElasticSearchInit']['return'] = 1;
         yield [
             $this->createMock(HttpRequest::class),
-            'wbstackElasticSearchInit call for <WIKI_ID> was not successful:{"warnings":[],"wbstackElasticSearchInit":{"success":1,"output":[]}}',
+            'wbstackElasticSearchInit call for <WIKI_ID> was not successful:{"warnings":[],"wbstackElasticSearchInit":{"return":1,"output":[]}}',
             $mockResponse
         ];
 


### PR DESCRIPTION
The api call does not return `success` but rather `return`, use that instead.