### PR TITLE
Enable setting a read only setting for a wiki

### DIFF
--- a/app/Console/Commands/Wiki/SetSetting.php
+++ b/app/Console/Commands/Wiki/SetSetting.php
@@ -8,7 +8,7 @@ use Illuminate\Console\Command;
 
 class SetSetting extends Command
 {
-    protected $signature = 'wbs-wiki:setSetting {wikiKey} {wikiValue} {settingKey} {settingValue}';
+    protected $signature = 'wbs-wiki:setSetting {wikiKey} {wikiValue} {settingKey} {settingValue?}';
 
     protected $description = 'Set a single setting for a wiki.';
 
@@ -22,7 +22,10 @@ class SetSetting extends Command
         $wikiKey = trim($this->argument('wikiKey'));
         $wikiValue = trim($this->argument('wikiValue'));
         $settingKey = trim($this->argument('settingKey'));
-        $settingValue = trim($this->argument('settingValue'));
+        $settingValue = $this->argument('settingValue');
+        if(is_string($settingValue)) {
+            $settingValue = trim($settingValue);
+        }
 
         // TODO don't select the timestamps and redundant info for the settings?
         $wiki = Wiki::where($wikiKey, $wikiValue)->first();
@@ -33,7 +36,16 @@ class SetSetting extends Command
         }
         $wikiId = $wiki->id;
 
-        $setting = WikiSetting::updateOrCreate(
+        if($settingValue === null) {
+            WikiSetting::where([
+                'wiki_id' => $wiki->id,
+                'name' => $settingKey,
+            ])->delete();
+            $this->line("Deleted setting ${settingKey} for wiki id ${wikiId}");
+            return;
+        }
+
+        WikiSetting::updateOrCreate(
             [
                 'wiki_id' => $wiki->id,
                 'name' => $settingKey,

--- a/app/Http/Controllers/WikiSettingController.php
+++ b/app/Http/Controllers/WikiSettingController.php
@@ -16,7 +16,7 @@ class WikiSettingController extends Controller
      */
     private function getSettingValidations(): array
     {
-        // FIXME: this list is evil and should be kept in sync with the model in Wiki.php?!
+        // FIXME: this list is evil and should be kept in sync with the model in Wiki.php?! (mostly)
         return [
             'wgDefaultSkin' => ['required', 'string', 'in:vector,modern,timeless'],
             'wwExtEnableConfirmAccount' => ['required', 'boolean'],

--- a/app/Wiki.php
+++ b/app/Wiki.php
@@ -100,6 +100,7 @@ class Wiki extends Model
         return $this->settings()->whereIn('name',
         [
             'wgLogo',
+            'wgReadOnly',
             // FIXME: this list is evil and should be kept in sync with WikiSettingController?!
             'wgDefaultSkin',
             'wwExtEnableConfirmAccount',


### PR DESCRIPTION
This also allows the set setting command for a wiki
to be able to set it to blank / delete the entry.
This is ONLY setable internally by the platform, and not via the API.

The command would be:
php artisan wbs-wiki:setSetting

And you can use something like the following to set readonly:
domain wiki1.wbaas.localhost wgReadOnly "Message here"

Or this to unset:
domain wiki1.wbaas.localhost wgReadOnly

This is for https://phabricator.wikimedia.org/T298759
and also has a MediaWiki PR for the config
https://github.com/wbstack/mediawiki/pull/197
