### PR TITLE
Fix WikiFactory

### DIFF
--- a/database/factories/ModelFactory.php
+++ b/database/factories/ModelFactory.php
@@ -25,14 +25,6 @@ $factory->define(App\Invitation::class, function (Faker\Generator $faker) {
     ];
 });
 
-$factory->define(App\Wiki::class, function (Faker\Generator $faker) {
-    $subDomainSuffix = Illuminate\Support\Facades\Config::get('wbstack.subdomain_suffix');
-    return [
-        'sitename' => $faker->name,
-        'domain' => str_replace(' ', '_', substr(strtolower($faker->unique->text), 0, 11)).$subDomainSuffix,
-    ];
-});
-
 $factory->define(App\WikiManager::class, function (Faker\Generator $faker) {
     // Attributes must be defined byt the caller
     return [];

--- a/database/factories/WikiFactory.php
+++ b/database/factories/WikiFactory.php
@@ -21,9 +21,11 @@ class WikiFactory extends Factory
      */
     public function definition()
     {
+        $subDomainSuffix = config('wbstack.subdomain_suffix');
+
         return [
-            'sitename' => $this->faker->text(5),
-            'domain' => $this->faker->domainName
+            'sitename' => $this->faker->name,
+            'domain' => str_replace(' ', '_', substr(strtolower($this->faker->unique->text), 0, 11)).$subDomainSuffix,
         ];
     }
 }


### PR DESCRIPTION
The faker in `ModelFactory` was not used.

There was a suspicious failure in #309 (https://github.com/wbstack/api/runs/4805489685?check_suite_focus=true) and it turns out that the `WikiFactory` wasn't using the definition as expected. I haven't checked the other factories but looking at the docs this seems to have changed with the latest major laravel version:
https://laravel.com/docs/8.x/database-testing#defining-model-factories
https://laravel.com/docs/7.x/database-testing#writing-factories