### PR TITLE
Move elasticsearch host usage to config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.9.0 - 22 June 2022
+- Move elasticsearch host usage to config
+
 ## 8x.8.18 - 21 June 2022
 - Slim down /main endpoint response
 

--- a/app/Jobs/ElasticSearchIndexDelete.php
+++ b/app/Jobs/ElasticSearchIndexDelete.php
@@ -6,6 +6,7 @@ use App\WikiSetting;
 use App\Http\Curl\HttpRequest;
 use App\Wiki;
 use App\Helper\ElasticSearchHelper;
+use Illuminate\Support\Facades\Config;
 
 class ElasticSearchIndexDelete extends Job implements ShouldBeUnique
 {
@@ -60,10 +61,10 @@ class ElasticSearchIndexDelete extends Job implements ShouldBeUnique
         }
         
         $elasticSearchBaseName = $wikiDB->name;
-        $elasticSearchHost = getenv('ELASTICSEARCH_HOST');
+        $elasticSearchHost = Config::get('wbstack.elasticsearch_host');
         
         if( !$elasticSearchHost ) {
-            $this->fail( new \RuntimeException('ELASTICSEARCH_HOST not configured') );
+            $this->fail( new \RuntimeException('wbstack.elasticsearch_host not configured') );
             return;
         }
         try{

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -14,4 +14,5 @@ return [
     'platform_summary_email' => env('WBSTACK_MONITORING_EMAIL', 'monitoring@example.com'),
     'platform_summary_inactive_threshold' => env('WBSTACK_SUMMARY_INACTIVE_THRESHOLD', 60 * 60 * 24 * 90),
 
+    'elasticsearch_host' => env('ELASTICSEARCH_HOST', false),
 ];

--- a/tests/Jobs/Integration/ElasticSearchIndexDeleteTest.php
+++ b/tests/Jobs/Integration/ElasticSearchIndexDeleteTest.php
@@ -13,6 +13,7 @@ use App\Http\Curl\CurlRequest;
 use App\WikiDb;
 use Illuminate\Contracts\Queue\Job;
 use Illuminate\Foundation\Bus\DispatchesJobs;
+use Illuminate\Support\Facades\Config;
 
 /**
  * This is only meant to run when services is started with 
@@ -63,11 +64,12 @@ class ElasticSearchIndexDeleteTest extends TestCase
             $this->markTestSkipped('No blazegraph instance to connect to');
         }
 
-        if ( !getenv('ELASTICSEARCH_HOST') ) {
-            throw new \Exception('ELASTICSEARCH_HOST not set');
+        $ELASTICSEARCH_HOST=Config::get('wbstack.elasticsearch_host');
+
+        if ( !$ELASTICSEARCH_HOST ) {
+            throw new \Exception('ELASTICSEARCH_HOST / wbstack.elasticsearch_host not set');
         }
 
-        $ELASTICSEARCH_HOST=getenv('ELASTICSEARCH_HOST');
 
         $response = $this->makeRequest("http://$ELASTICSEARCH_HOST/someotherdbname_general_first?pretty", 'PUT');
         $this->assertTrue($response['acknowledged']);


### PR DESCRIPTION
Moves usage of ES host to be read from Config instead of getenv