### PR TITLE
Add seperate Xdebug configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,3 +12,10 @@ test-fresh: init test
 
 lint:
 	docker-compose exec -T api vendor/bin/psalm
+
+# Example: make test-xdebug FILTER=tests/Jobs/ElasticSearchIndexInitTest.php
+test-xdebug:
+	docker-compose exec api bash -c 'PHP_IDE_CONFIG="serverName=wbaas-local-api" XDEBUG_SESSION=1 php vendor/bin/phpunit ${FILTER}'
+
+xdebug:
+	docker-compose -f docker-compose.debug.yml up -d

--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,5 @@ test-fresh: init test
 lint:
 	docker-compose exec -T api vendor/bin/psalm
 
-# Example: make test-xdebug FILTER=tests/Jobs/ElasticSearchIndexInitTest.php
-test-xdebug:
-	docker-compose exec api bash -c 'PHP_IDE_CONFIG="serverName=wbaas-local-api" XDEBUG_SESSION=1 php vendor/bin/phpunit ${FILTER}'
-
 xdebug:
 	docker-compose -f docker-compose.debug.yml up -d

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -1,0 +1,56 @@
+FROM composer@sha256:d374b2e1f715621e9d9929575d6b35b11cf4a6dc237d4a08f2e6d1611f534675 as composer
+# composer is pinned at a PHP 7 version
+
+COPY ./composer.json /tmp/src1/composer.json
+COPY ./composer.lock /tmp/src1/composer.lock
+
+WORKDIR /tmp/src1
+RUN composer install --no-dev --no-progress --no-autoloader
+
+COPY ./ /tmp/src2
+RUN cp -r /tmp/src1/vendor /tmp/src2/vendor
+WORKDIR /tmp/src2
+RUN composer install --no-dev --no-progress --optimize-autoloader
+
+
+FROM php:7.4-apache
+
+RUN apt-get update \
+	# Needed for the imagick php extension install
+	&& apt-get install -y --no-install-recommends libmagickwand-dev \
+	&& echo "" | pecl install imagick \
+	&& docker-php-ext-enable imagick \
+	# Obviously needed for mysql connection
+	&& docker-php-ext-install pdo pdo_mysql \
+	# For rewrite rules
+	&& a2enmod rewrite \
+	# Needed for gluedev/laravel-stackdriver
+	&& pecl install opencensus-alpha \
+	&& docker-php-ext-enable opencensus \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN pecl install xdebug \
+    && docker-php-ext-enable xdebug
+
+RUN echo "zend_extension=xdebug\n\n\
+[xdebug]\n\
+xdebug.mode=develop,debug\n\
+xdebug.client_host=host.docker.internal\n\
+xdebug.client_port=9003\n\
+" > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+
+ENV APACHE_DOCUMENT_ROOT /var/www/html/public
+
+# Change the document root
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \
+    && sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+COPY --chown=www-data:www-data --from=composer /tmp/src2 /var/www/html
+
+WORKDIR /var/www/html
+
+COPY ./start.sh /usr/local/bin/start
+
+CMD ["/usr/local/bin/start"]
+
+LABEL org.opencontainers.image.source="https://github.com/wbstack/api"

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -39,6 +39,9 @@ xdebug.client_host=host.docker.internal\n\
 xdebug.client_port=9003\n\
 " > /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
 
+ENV PHP_IDE_CONFIG "serverName=wbaas-local-api"
+ENV XDEBUG_SESSION 1
+
 ENV APACHE_DOCUMENT_ROOT /var/www/html/public
 
 # Change the document root

--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,0 +1,50 @@
+version: '2'
+services:
+  api:
+    build:
+      dockerfile: debug.Dockerfile
+      context: .
+    volumes:
+      - ./:/var/www/html
+      - ./start.sh:/usr/local/bin/start
+      - api-storage:/var/www/html/storage/
+      - ./words:/words
+    ports:
+      - 8082:80
+    restart: always
+    depends_on:
+      - sql
+    links:
+      - sql
+      - redis
+    environment:
+      - CONTAINER_ROLE=app
+    extra_hosts:
+      - host.docker.internal:host-gateway
+  sql:
+    image: "${DOCKER_DATABASE_IMAGE_NAME}"
+    environment:
+      MYSQL_ROOT_PASSWORD: imarootpassword
+      MYSQL_DATABASE: apidb
+    restart: always
+    volumes:
+      - sql-data:/var/lib/mysql
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:4.8
+    restart: always
+    ports:
+      - 8070:80
+    environment:
+      PMA_HOST: 'sql'
+      PMA_PORT: 3306
+      PMA_USER: 'root'
+      PMA_PASSWORD: 'imarootpassword'
+  redis:
+    image: redis:latest
+    restart: always
+    expose:
+      - 6379
+
+volumes:
+  sql-data:
+  api-storage:


### PR DESCRIPTION
This PR adds some separate configuration to use Xdebug when developing with docker-compose.

There's a separate Dockerfile, which installs and configures Xdebug, and a docker-compose file which uses that Dockerfile, plus adding the docker host for the container.

To run the container in 'xdebug mode' I added the `xdebug` command to our Makefile, which builds and runs the container with the configuration above. Once that is running you can use `make test` and you should be able to use Xdebug with your IDE :tada: (note: I only tested this with PhpStorm)

If we agree that we want this in the repo I'll add some docs before merging, because the usage isnt quite obvious I think.
