### PR TITLE
Artisan Job to create Wikis and associated Models

### DIFF
--- a/app/Jobs/CreateEmptyWikiDb.php
+++ b/app/Jobs/CreateEmptyWikiDb.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace App\Jobs;
+
+use App\WikiDb;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\DatabaseManager;
+
+/**
+ * Only used in the migration from WBStack to wikibase.cloud
+ *
+ * Example usage that will always provision a new DB:
+ * php artisan job:dispatchNow ProvisionWikiDbJob
+ */
+class CreateEmptyWikiDb extends Job
+{
+    private $dbName;
+
+    private $dbUser;
+
+    private $dbPassword;
+
+    private $prefix;
+
+    private $wikiDb;
+
+    public function __construct(string $prefix)
+    {
+        $this->dbName = 'mwdb_wbstack_'.substr(bin2hex(random_bytes(48)), 0, 10);
+        $this->dbUser = 'mwu_'.substr(bin2hex(random_bytes(48)), 0, 10);
+        $this->dbPassword = substr(bin2hex(random_bytes(48)), 0, 14);
+        $this->prefix = $prefix;
+    }
+
+    public function getWikiDb() {
+        return $this->wikiDb;
+    }
+
+    /**
+     * @return void
+     */
+    public function handle( DatabaseManager $manager )
+    {
+        $manager->purge('mw');
+        $conn = $manager->connection('mw');
+        if (! $conn instanceof \Illuminate\Database\Connection) {
+            $this->fail(new \RuntimeException('Must be run on a PDO based DB connection'));
+
+            return; //safegaurd
+        }
+        $pdo = $conn->getPdo();
+
+        // CREATE THE USER
+        // This looks stupid because it is.
+        // For some reason the mediawiki-db-manager user seems to be able to create user
+        // but these exec call to the PDO seems to throw an exception saying:
+        // PDOException: SQLSTATE[HY000]: General error: 1396 Operation CREATE USER failed for 'mwu_0985131dfa'@'%'
+        // So, catch this exception and check the error state ourselves, and allow us to continue past this?
+        try {
+            $conn->statement("CREATE USER '".$this->dbUser."'@'%' IDENTIFIED BY '".$this->dbPassword."'");
+        } catch (\Illuminate\Database\QueryException $e) {
+            // Probably fine, and if not fine then the ALTER will fail below? :)
+            $conn->statement("ALTER USER '".$this->dbUser."'@'%' IDENTIFIED BY '".$this->dbPassword."'");
+        }
+
+        // CREATE (maybe) AND USE DB
+        if ($this->dbName) {
+            if ($pdo->exec('CREATE DATABASE IF NOT EXISTS '.$this->dbName) === false) {
+                $this->fail(
+                    new \RuntimeException('Failed to create database with dbname: '.$this->dbName)
+                );
+
+                return; //safegaurd
+            }
+        } else {
+            // Default to mediawiki
+            $this->dbName = 'mediawiki';
+        }
+        if ($pdo->exec('USE '.$this->dbName) === false) {
+            $this->fail(
+                new \RuntimeException('Failed to use database with dbname: '.$this->dbName)
+            );
+
+            return; //safegaurd
+        }
+
+        // GRANT THE USER ACCESS TO THE DB
+        // TODO more limited GRANTS...
+        // TODO cant grant based on table prefix, so maybe do have seperate dbs...?
+        if ($pdo->exec('GRANT ALL ON '.$this->dbName.'.* TO \''.$this->dbUser.'\'@\'%\'') === false) {
+            $this->fail(
+                new \RuntimeException('Failed to grant user: '.$this->dbUser)
+            );
+
+            return; //safegaurd
+        }
+
+        // Figure out the SQL version
+        $stmt = $pdo->query("SELECT version() AS version");
+        $fullVersion = $stmt->fetch()['version']; // "10.5.12-MariaDB-log"
+        preg_match('/^(\d+\.\d+\.\d+)(?!\d).*?$/', $fullVersion, $versionMatches); // [ 0 => '10.5.12-MariaDB-log', 1 => '10.5.12' ]
+        $sqlVersion = $versionMatches[1]; // '10.5.12'
+        $aboveMariaDb1059 = version_compare($sqlVersion,'10.5.9'); // 1 = higher, 0 = same, -1 = lower
+        $aboveMariaDb1052 = version_compare($sqlVersion,'10.5.2'); // 1 = higher, 0 = same, -1 = lower
+
+        if($aboveMariaDb1052 >= 0 && $aboveMariaDb1059 == -1) {
+            $this->fail(
+                new \RuntimeException('Can not succeed on MariaDB versions between 10.5.2 and 10.5.9')
+            );
+        }
+        if($aboveMariaDb1059 == -1) {
+            // GRANT the user access to see slave status
+            // GRANT REPLICATION CLIENT ON *.* TO 'mwu_36be7164b0'@'%'
+            if ($pdo->exec('GRANT REPLICATION CLIENT ON *.* TO \''.$this->dbUser.'\'@\'%\'') === false) {
+                $this->fail(
+                    new \RuntimeException('Failed to grant user: '.$this->dbUser)
+                );
+
+                return;
+            }
+        }
+        if($aboveMariaDb1059 >= 0) {
+            // GRANT the user access to see slave status
+            // Mariadb versions > 10.5.9 https://mariadb.com/kb/en/grant/#replica-monitor
+            // https://mariadb.com/docs/reference/mdb/privileges/BINLOG_MONITOR/ required to query "SHOW MASTER STATUS"
+            // GRANT REPLICA MONITOR, BINLOG MONITOR ON *.* TO 'mwu_36be7164b0'@'%'
+            if ($pdo->exec('GRANT REPLICA MONITOR, BINLOG MONITOR ON *.* TO \''.$this->dbUser.'\'@\'%\'') === false) {
+                $this->fail(
+                    new \RuntimeException('Failed to grant REPLICA MONITOR to user: '.$this->dbUser)
+                );
+
+                return;
+            }
+        }
+
+        // TODO per plan, create some record before the above transaction stuff happens..
+        // so:
+        //  - Add wikiDb record, stating pending state?
+        //  - Create the DB and tables in a TRANSACTION
+        //  - update the wikiDb Record on success
+        //
+        //  This way, if this wikiDb create fails, there is still a record of the DB that has been / is being created?
+        $this->wikiDb = WikiDb::create([
+          'name' => $this->dbName,
+          'user' => $this->dbUser,
+          'password' => $this->dbPassword,
+          // TODO: this should be chaged in update.php
+          'version' => "wbstack-migrate",
+          'prefix' => $this->prefix,
+      ]);
+
+      $manager->purge('mw');
+    }
+}

--- a/app/Jobs/CreateEmptyWikiDb.php
+++ b/app/Jobs/CreateEmptyWikiDb.php
@@ -8,9 +8,10 @@ use Illuminate\Database\DatabaseManager;
 
 /**
  * Only used in the migration from WBStack to wikibase.cloud
+ * To be deleted after migration
  *
  * Example usage that will always provision a new DB:
- * php artisan job:dispatchNow ProvisionWikiDbJob
+ * php artisan job:dispatchNow CreateEmptyWikiDb
  */
 class CreateEmptyWikiDb extends Job
 {

--- a/app/Jobs/MigrationWikiCreate.php
+++ b/app/Jobs/MigrationWikiCreate.php
@@ -5,16 +5,11 @@ namespace App\Jobs;
 use App\QueryserviceNamespace;
 use App\User;
 use App\Wiki;
-use App\WikiDb;
 use App\WikiDomain;
 use App\WikiManager;
 use App\WikiSetting;
-use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Config;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Database\DatabaseManager;
-use Illuminate\Support\Str;
-use Lcobucci\JWT\Exception;
 
 /*
     - This will create a laravel Wiki object and persist it
@@ -55,14 +50,13 @@ class MigrationWikiCreate extends Job
         $wikiDetails = json_decode(file_get_contents($this->wikiDetailsFilepath));
 
         foreach ($wikiDetails->settings as $setting) {
-            if ($setting['name'] === "wikibaseFedPropsEnable") {
-                if ($setting['value'] == '1') {
+            if ($setting->name === "wikibaseFedPropsEnable") {
+                if ($setting->value == '1') {
                     die("Migration aborted; Feddy props detected!");
                 }
                 break;
             }
         }
-
 
         $prefix = $wikiDetails->wiki_db->prefix;
         $emptyWikiDbJob = new CreateEmptyWikiDb($prefix);

--- a/app/Jobs/MigrationWikiCreate.php
+++ b/app/Jobs/MigrationWikiCreate.php
@@ -103,10 +103,15 @@ class MigrationWikiCreate extends Job
     }
 
     /**
-     * @return void
+     * @param $user
+     * @param $wikiDetails
+     * @param $wikiDb
+     * @return Wiki
      */
     private function createWiki($user, $wikiDetails, $wikiDb) {
-        DB::transaction(function () use ($user, $wikiDetails, $wikiDb) {
+        $wiki = null;
+
+        DB::transaction(function () use (&$wiki, $user, $wikiDetails, $wikiDb) {
             $wiki = Wiki::create([
                 'sitename' => $wikiDetails->sitename,
                 'domain' => strtolower($wikiDetails->domain),
@@ -147,5 +152,7 @@ class MigrationWikiCreate extends Job
                 'wiki_id' => $wiki->id,
             ]);
         });
+
+        return $wiki;
     }
 }

--- a/app/Jobs/MigrationWikiCreate.php
+++ b/app/Jobs/MigrationWikiCreate.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Jobs;
+
+use App\QueryserviceNamespace;
+use App\User;
+use App\Wiki;
+use App\WikiDb;
+use App\WikiDomain;
+use App\WikiManager;
+use App\WikiSetting;
+use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Database\DatabaseManager;
+use Illuminate\Support\Str;
+use Lcobucci\JWT\Exception;
+
+/*
+    - This will create a laravel Wiki object and persist it
+    - This Wiki object will be owned by a user that has the email address
+    - A WikiDb will exist; it will have no tables but it will have grants for a) the wiki manager user and b) a specific user for this db
+    - The wiki settings will be attached to the Wiki
+    - A queryservice namespace will be assigned to this Wiki
+*/
+
+class MigrationWikiCreate extends Job
+{
+    private $wikiDetailsFilepath;
+    private $email;
+
+    /**
+     * @param string $email the email of the user to own this wiki
+     * @param string $wikiDetailsFilepath file path to a `wiki-details.json` file, created with `php artisan wbs-wiki:get domain $DOMAIN`
+     *
+     * @return void
+     */
+    public function __construct($email, $wikiDetailsFilepath)
+    {
+        $this->email = $email;
+        $this->wikiDetailsFilepath = $wikiDetailsFilepath;
+    }
+
+    /**
+     * @return void
+     */
+    public function handle( DatabaseManager $manager )
+    {
+        $user = User::where('email', $this->email)->get();
+
+        if ($user->count() !== 1) {
+            $this->fail( new \RuntimeException('Error: there were '.$user->count().' users found with `email`: '.$this->email) );
+            return;
+        }
+
+        if (! is_readable($this->wikiDetailsFilepath)) {
+            $this->fail( new \RuntimeException('Error: the wiki-details json file is not readable (does the file exist? is the path correct?') );
+            return;
+        }
+
+        $wikiDetails = json_decode(file_get_contents($this->wikiDetailsFilepath));
+
+        $wikiDb = $this->createWikiDb($manager);
+        $this->createWiki($user, $wikiDetails, $wikiDb);
+
+        return true;
+    }
+
+    /**
+     * @return WikiDb
+     */
+    private function createWikiDb($manager) {
+        $manager->purge('mw');
+        $conn = $manager->connection('mw');
+        if (! $conn instanceof \Illuminate\Database\Connection) {
+            $this->fail(new \RuntimeException('Must be run on a PDO based DB connection'));
+
+            return; //safegaurd
+        }
+        $pdo = $conn->getPdo();
+
+        $wikiDb = WikiDb::create([
+            'name' => $this->dbName,
+            'user' => $this->dbUser,
+            'password' => $this->dbPassword,
+            'version' => $this->newSqlFile,
+            'prefix' => $this->prefix,
+        ]);
+
+        $manager->purge('mw');
+
+        return $wikiDb;
+    }
+
+    /**
+     * @return void
+     */
+    private function createWiki($user, $wikiDetails, $wikiDb) {
+        DB::transaction(function () use ($user, $wikiDetails, &$wiki, &$dbAssignment) {
+            $dbVersion = Config::get('wbstack.wiki_db_use_version');
+            $wikiDbCondition = ['wiki_id'=>null, 'version'=>$dbVersion];
+
+            $wiki = Wiki::create([
+                'sitename' => $wikiDetails->sitename,
+                'domain' => strtolower($wikiDetails->domain),
+            ]);
+
+            // Assign storage
+            $dbAssignment = DB::table('wiki_dbs')->where($wikiDbCondition)->limit(1)->update(['wiki_id' => $wiki->id]);
+            if (! $dbAssignment) {
+                abort(503, 'Database ready, but failed to assign');
+            }
+            $nsAssignment = DB::table('queryservice_namespaces')->where(['wiki_id'=>null])->limit(1)->update(['wiki_id' => $wiki->id]);
+            if (! $nsAssignment) {
+                abort(503, 'QS Namespace ready, but failed to assign');
+            }
+
+            // Create initial needed non default settings
+            // Docs: https://www.mediawiki.org/wiki/Manual:$wgSecretKey
+            WikiSetting::create([
+                'wiki_id' => $wiki->id,
+                'name' => WikiSetting::wgSecretKey,
+                'value' => Str::random(64),
+            ]);
+
+            // Create the enabled elasticsearch setting
+            // T285541
+            WikiSetting::create([
+                'wiki_id' => $wiki->id,
+                'name' => WikiSetting::wwExtEnableElasticSearch,
+                'value' => true,
+            ]);
+
+            // Also track the domain forever in your domains table
+            $wikiDomain = WikiDomain::create([
+                'domain' => $wiki->domain,
+                'wiki_id' => $wiki->id,
+            ]);
+
+            $ownerAssignment = WikiManager::create([
+                'user_id' => $user->id,
+                'wiki_id' => $wiki->id,
+            ]);
+        });
+    }
+}

--- a/app/Jobs/MigrationWikiCreate.php
+++ b/app/Jobs/MigrationWikiCreate.php
@@ -29,6 +29,12 @@ class MigrationWikiCreate extends Job
     private $wikiDetailsFilepath;
     private $email;
 
+    private $prefix;
+    private $newSqlFile;
+    private $dbName;
+    private $dbUser;
+    private $dbPassword;
+
     /**
      * @param string $email the email of the user to own this wiki
      * @param string $wikiDetailsFilepath file path to a `wiki-details.json` file, created with `php artisan wbs-wiki:get domain $DOMAIN`
@@ -39,6 +45,12 @@ class MigrationWikiCreate extends Job
     {
         $this->email = $email;
         $this->wikiDetailsFilepath = $wikiDetailsFilepath;
+
+        $this->dbUser = 'mwu_'.substr(bin2hex(random_bytes(48)), 0, 10);
+        $this->dbPassword = substr(bin2hex(random_bytes(48)), 0, 14);
+        $this->prefix = 'mwt_'.substr(bin2hex(random_bytes(48)), 0, 10);
+        $this->dbName = 'mwdb_'.substr(bin2hex(random_bytes(48)), 0, 10);
+        $this->newSqlFile = config('wbstack.wiki_db_provision_version');
     }
 
     /**
@@ -62,8 +74,6 @@ class MigrationWikiCreate extends Job
 
         $wikiDb = $this->createWikiDb($manager);
         $this->createWiki($user, $wikiDetails, $wikiDb);
-
-        return true;
     }
 
     /**

--- a/app/Jobs/MigrationWikiCreate.php
+++ b/app/Jobs/MigrationWikiCreate.php
@@ -29,11 +29,6 @@ class MigrationWikiCreate extends Job
     private $email;
     private $wikiDetailsFilepath;
 
-    private $prefix;
-    private $dbName;
-    private $dbUser;
-    private $dbPassword;
-
     /**
      * @param string $email the email of the user to own this wiki
      * @param string $wikiDetailsFilepath file path to a `wiki-details.json` file, created with `php artisan wbs-wiki:get domain $DOMAIN`
@@ -44,11 +39,6 @@ class MigrationWikiCreate extends Job
     {
         $this->email = $email;
         $this->wikiDetailsFilepath = $wikiDetailsFilepath;
-
-        $this->dbUser = 'mwu_'.substr(bin2hex(random_bytes(48)), 0, 10);
-        $this->dbPassword = substr(bin2hex(random_bytes(48)), 0, 14);
-        $this->prefix = 'mwt_'.substr(bin2hex(random_bytes(48)), 0, 10);
-        $this->dbName = 'mwdb_'.substr(bin2hex(random_bytes(48)), 0, 10);
     }
 
     /**

--- a/tests/Jobs/MigrationWikiCreateTest.php
+++ b/tests/Jobs/MigrationWikiCreateTest.php
@@ -3,17 +3,16 @@
 namespace Tests\Jobs;
 
 use App\Jobs\MigrationWikiCreate;
-use App\User;
-use Illuminate\Foundation\Testing\DatabaseTransactions;
-use Tests\TestCase;
-use App\WikiManager;
-use App\Wiki;
-use Illuminate\Contracts\Queue\Job;
-use App\WikiDomain;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use App\QueryserviceNamespace;
+use App\User;
+use App\Wiki;
 use App\WikiDb;
+use App\WikiDomain;
+use App\WikiManager;
 use App\WikiSetting;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Contracts\Queue\Job;
+use Tests\TestCase;
 
 class MigrationWikiCreateTest extends TestCase
 {

--- a/tests/Jobs/MigrationWikiCreateTest.php
+++ b/tests/Jobs/MigrationWikiCreateTest.php
@@ -18,6 +18,8 @@ class MigrationWikiCreateTest extends TestCase
         parent::setUp();
     }
 
+    // note: I tried to split this test into several test cases,
+    // but it seems like the DB transactions get rolled back after every test case?
     public function testMigrationWikiCreateRunsWithoutFailure()
     {
         $wikiDetailsFilepath = __DIR__.'/../data/example-wiki-details.json';

--- a/tests/Jobs/MigrationWikiCreateTest.php
+++ b/tests/Jobs/MigrationWikiCreateTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Jobs;
+
+use App\Jobs\MigrationWikiCreate;
+use App\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use App\Http\Curl\HttpRequest;
+use App\WikiManager;
+use App\WikiSetting;
+use App\Wiki;
+use App\Jobs\ElasticSearchIndexDelete;
+use App\WikiDb;
+use Illuminate\Contracts\Queue\Job;
+
+class MigrationWikiCreateTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    private $wiki;
+    private $user;
+    private $wikiDb;
+
+    public function setUp(): void {
+        parent::setUp();
+    }
+
+    public function testMigrationWikiCreate()
+    {
+        $email = 'foobar@example.com';
+        $wikiDetailsFilepath = __DIR__.'/../data/example-wiki-details.json';
+
+        $user = User::factory()->create([
+            'verified' => true,
+            'email' => $email,
+        ]);
+
+        $mockJob = $this->createMock(Job::class);
+        $mockJob->expects($this->never())->method('fail');
+
+        $manager = $this->app->make('db');
+
+        $job = new MigrationWikiCreate($email, $wikiDetailsFilepath);
+        $job->setJob( $mockJob );
+        $job->handle($manager);
+    }
+}

--- a/tests/Jobs/MigrationWikiCreateTest.php
+++ b/tests/Jobs/MigrationWikiCreateTest.php
@@ -33,6 +33,7 @@ class MigrationWikiCreateTest extends TestCase
 
         $user = User::factory()->create([
             'verified' => true,
+            'id' => 9001,
             'email' => $email,
         ]);
 

--- a/tests/data/example-wiki-details.json
+++ b/tests/data/example-wiki-details.json
@@ -1,0 +1,53 @@
+{
+  "id": 1,
+  "domain": "deerdeerdeer.wbaas.localhost",
+  "sitename": "DeerDeerDeer",
+  "deleted_at": null,
+  "created_at": "2022-01-18T15:32:17.000000Z",
+  "updated_at": "2022-01-18T15:32:17.000000Z",
+  "wiki_db": {
+    "id": 1,
+    "name": "mwdb_3a7fd89919",
+    "prefix": "mwt_28d20b0972",
+    "user": "mwu_720ef4f698",
+    "password": "26a72789bebfef",
+    "version": "mw1.37-fp-wbs1",
+    "wiki_id": 1,
+    "created_at": "2022-01-17T15:10:17.000000Z",
+    "updated_at": "2022-01-17T15:10:17.000000Z"
+  },
+  "wiki_queryservice_namespace": {
+    "id": 1,
+    "namespace": "qsns_71541d0c8b",
+    "backend": "queryservice.default.svc.cluster.local:9999",
+    "wiki_id": 1,
+    "created_at": "2022-01-17T15:10:17.000000Z",
+    "updated_at": "2022-01-17T15:10:17.000000Z"
+  },
+  "settings": [
+    {
+      "id": 1,
+      "name": "wgSecretKey",
+      "value": "DeYcBIThioSdJbbjmkQW3yBDIQNwbHplQQ6Aca6bOI9f6Mv6CsnldaZiPm2ISZTc",
+      "wiki_id": 1,
+      "created_at": "2022-01-18T15:32:17.000000Z",
+      "updated_at": "2022-01-18T15:32:17.000000Z"
+    },
+    {
+      "id": 2,
+      "name": "wwExtEnableElasticSearch",
+      "value": "0",
+      "wiki_id": 1,
+      "created_at": "2022-01-18T15:32:17.000000Z",
+      "updated_at": "2022-01-18T15:34:22.000000Z"
+    },
+    {
+      "id": 3,
+      "name": "wwExtEnableConfirmAccount",
+      "value": "1",
+      "wiki_id": 1,
+      "created_at": "2022-01-18T15:33:12.000000Z",
+      "updated_at": "2022-01-18T15:33:19.000000Z"
+    }
+  ]
+}


### PR DESCRIPTION
- [x] This PR introduces an artisan job that will create a laravel Wiki object and persist it
- [x] This Wiki object will be owned by a user that has the email address
- [x] A WikiDb will exist; it will have no tables but it will have grants for a) the wiki manager user and b) a specific user for this db
- [x] The wiki settings will be attached to the Wiki
- [x] A queryservice namespace will be assigned to this Wiki


https://phabricator.wikimedia.org/T298952

