### PR TITLE
Specifically require http/socket-client:2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "maclof/kubernetes-client": "^0.23.0",
         "mxl/laravel-job": "^1.2",
         "percymamedy/laravel-dev-booter": "^3.0",
+        "php-http/socket-client": "2.0.2",
         "predis/predis": "^1.1",
         "superbalist/laravel-google-cloud-storage": "^2.2"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e70b8ecd7a00899c5780692081d1811b",
+    "content-hash": "d9654e47a8198223a80ad16acc51f90b",
     "packages": [
         {
             "name": "albertcht/invisible-recaptcha",
@@ -5003,34 +5003,35 @@
         },
         {
             "name": "php-http/socket-client",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/socket-client.git",
-                "reference": "3db137a526c467b52d8d743f5c2f7fdcc00362ef"
+                "reference": "a53d9c25e34ae3c39d07158b7ae7bf25b83b300a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/socket-client/zipball/3db137a526c467b52d8d743f5c2f7fdcc00362ef",
-                "reference": "3db137a526c467b52d8d743f5c2f7fdcc00362ef",
+                "url": "https://api.github.com/repos/php-http/socket-client/zipball/a53d9c25e34ae3c39d07158b7ae7bf25b83b300a",
+                "reference": "a53d9c25e34ae3c39d07158b7ae7bf25b83b300a",
                 "shasum": ""
             },
             "require": {
-                "nyholm/psr7": "^1.0",
+                "nyholm/psr7": "^1.3",
                 "php": "^7.1",
                 "php-http/httplug": "^2.0",
                 "psr/http-client": "^1.0",
-                "symfony/options-resolver": "^2.6 || ^3.0 || ^4.0 || ^5.0"
+                "symfony/options-resolver": "^2.6 || ^3.4 || ^4.4 || ^5.0"
             },
             "provide": {
                 "php-http/client-implementation": "1.0",
-                "psr/http-client": "1.0"
+                "psr/http-client-implementation": "1.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^2.2",
-                "php-http/client-common": "^2.0",
-                "php-http/client-integration-tests": "dev-master",
-                "php-http/message": "^1.0"
+                "php-http/client-common": "^2.3",
+                "php-http/client-integration-tests": "^3.0",
+                "php-http/message": "^1.9",
+                "phpunit/phpunit": "^8.5.8"
             },
             "type": "library",
             "extra": {
@@ -5056,9 +5057,9 @@
             "description": "Socket client for PHP-HTTP",
             "support": {
                 "issues": "https://github.com/php-http/socket-client/issues",
-                "source": "https://github.com/php-http/socket-client/tree/2.0.1"
+                "source": "https://github.com/php-http/socket-client/tree/2.0.2"
             },
-            "time": "2020-10-16T13:31:02+00:00"
+            "time": "2020-10-22T09:00:03+00:00"
         },
         {
             "name": "phpoption/phpoption",
@@ -5454,6 +5455,58 @@
                 "source": "https://github.com/php-fig/event-dispatcher/tree/1.0.0"
             },
             "time": "2019-01-08T18:20:26+00:00"
+        },
+        {
+            "name": "psr/http-client",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "reference": "2dfb5f6c5eff0e91e20e913f8c5452ed95b86621",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/master"
+            },
+            "time": "2020-06-29T06:28:15+00:00"
         },
         {
             "name": "psr/http-factory",


### PR DESCRIPTION
http/socket-client:2.0.1 has a bug becuase it claims to provide
psr/http-client yet it doesn't

We struggled to update this with `composer update` so for now
we specifically require this version