### PR TITLE
Add `auth.json` to `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor
+/auth.json
 /.idea
 Homestead.json
 Homestead.yaml


### PR DESCRIPTION
`auth.json` stores repository (e.g. github) tokens for use with `composer` to avoid being rate limited