### PR TITLE
Add checks for MW api errors in CirrusSearchJob

### DIFF
--- a/app/Jobs/CirrusSearch/CirrusSearchJob.php
+++ b/app/Jobs/CirrusSearch/CirrusSearchJob.php
@@ -91,6 +91,11 @@ abstract class CirrusSearchJob extends Job implements ShouldBeUnique
             return false;
         }
 
+        if( $this->hasApiError( $response ) ) {
+            $this->fail( new \RuntimeException( $this->apiModule() . ' call failed with api error: '. $response['error']['info'] ) );
+            return false;
+        }
+
         if ( !$this->isValid( $response ) ) {
             $this->fail( new \RuntimeException( $this->apiModule() . ' call for '.$this->wikiId.'. No ' . $this->apiModule() . ' key in response: '.$rawResponse) );
             return false;
@@ -106,6 +111,12 @@ abstract class CirrusSearchJob extends Job implements ShouldBeUnique
 
     protected function getRequestTimeout(): int {
         return 100;
+    }
+
+    // TODO Migrate this to some other baseclass for all internal api classes
+    // This and some other stuff would be usedful there too
+    protected function hasApiError( ?array $response ): bool {
+        return is_array($response) && array_key_exists( 'error', $response);
     }
 
     protected function isValid( ?array $response ): bool {

--- a/tests/data/mediawiki-api-error-response.json
+++ b/tests/data/mediawiki-api-error-response.json
@@ -1,0 +1,7 @@
+{
+    "error": {
+      "code": "badvalue",
+      "info": "Unrecognized value for parameter \"action\": wbstackQueueSearchIndexBatches.",
+      "*": "See http://minikube.wbaas.localhost/w/api.php for API usage. Subscribe to the mediawiki-api-announce mailing list at &lt;https://lists.wikimedia.org/postorius/lists/mediawiki-api-announce.lists.wikimedia.org/&gt; for notice of API deprecations and breaking changes."
+    }
+}


### PR DESCRIPTION
This add checks for errors that come from the Mediawiki API in CirrusSearchJobs, for example if a certain module isn't
 available or some database error this would get caught.