### PR TITLE
Allow forcesearchindex to fail

### DIFF
--- a/app/Jobs/CirrusSearch/CirrusSearchJob.php
+++ b/app/Jobs/CirrusSearch/CirrusSearchJob.php
@@ -103,7 +103,7 @@ abstract class CirrusSearchJob extends Job implements ShouldBeUnique
 
         return true;
     }
-    protected function validateSuccess( ?array $response, string $rawResponse, $error ): bool {
+    protected function validateSuccess( array $response, string $rawResponse, $error ): bool {
         if ( !$this->isSuccessful($response)) {
             $this->fail( new \RuntimeException( $this->apiModule() . ' call for '.$this->wikiId.' was not successful:'.$rawResponse) );
             return false;

--- a/app/Jobs/CirrusSearch/CirrusSearchJob.php
+++ b/app/Jobs/CirrusSearch/CirrusSearchJob.php
@@ -101,6 +101,9 @@ abstract class CirrusSearchJob extends Job implements ShouldBeUnique
             return false;
         }
 
+        return true;
+    }
+    protected function validateSuccess( ?array $response, string $rawResponse, $error ): bool {
         if ( !$this->isSuccessful($response)) {
             $this->fail( new \RuntimeException( $this->apiModule() . ' call for '.$this->wikiId.' was not successful:'.$rawResponse) );
             return false;

--- a/app/Jobs/CirrusSearch/ElasticSearchIndexInit.php
+++ b/app/Jobs/CirrusSearch/ElasticSearchIndexInit.php
@@ -14,7 +14,7 @@ class ElasticSearchIndexInit extends CirrusSearchJob
     {
         $response = json_decode( $rawResponse, true );
 
-        if( !$this->validateOrFailRequest($response, $rawResponse, $error) ) {
+        if( !$this->validateOrFailRequest($response, $rawResponse, $error) || !$this->validateSuccess($response, $rawResponse, $error) ) {
             $this->setting->update( [  'value' => false  ] );
             Log::warning( __METHOD__ . ": Failed initializing elasticsearch. Disabling the setting." );
             return;

--- a/app/Jobs/CirrusSearch/ForceSearchIndex.php
+++ b/app/Jobs/CirrusSearch/ForceSearchIndex.php
@@ -47,6 +47,10 @@ class ForceSearchIndex extends CirrusSearchJob
             return;
         }
 
+        if( !$this->validateSuccess($response, $rawResponse, $error) ) {
+            return;
+        }
+
         $output = $response[$this->apiModule()]['output'];
 
         $successMatches = [];

--- a/app/Jobs/CirrusSearch/QueueSearchIndexBatches.php
+++ b/app/Jobs/CirrusSearch/QueueSearchIndexBatches.php
@@ -60,6 +60,17 @@ class QueueSearchIndexBatches extends CirrusSearchJob
 
         $output = $response[$this->apiModule()]['output'];
 
+        // if there are no pages to index, just exit now.
+        if( !$this->isSuccessful($response) && 
+            is_array($output) && count($output) == 1 && $output[0] == "Couldn't find any pages to index.  fromId =  =  = toId." ) {
+            Log::warning(__METHOD__ . ": ForceSearchIndex could not find any pages to index. " . $rawResponse);
+            return;
+        }
+
+        if( !$this->validateSuccess($response, $rawResponse, $error) ) {
+            return;
+        }
+
         $batches = [];
 
         try {


### PR DESCRIPTION
this breaks out the success part of the request validation and makes
each job be responsible for acting on this.

Adds a check to QueueSearchIndexBatches to allow non-zero exits.

depends on https://github.com/wbstack/mediawiki/pull/242
