### PR TITLE
MigrationWikiCreate: Add test case for non-empty wgReadOnly

### DIFF
--- a/tests/Jobs/MigrationWikiCreateTest.php
+++ b/tests/Jobs/MigrationWikiCreateTest.php
@@ -139,7 +139,13 @@ class MigrationWikiCreateTest extends TestCase
 
         // The wiki settings will be attached to the Wiki
         $wikiSettings = WikiSetting::where(['wiki_id' => $wiki->id]);
-        $this->assertSame(3, $wikiSettings->count());
+        $this->assertSame(4, $wikiSettings->count());
+
+        // The wiki is set to read only
+        $wikiSettingReadOnly = WikiSetting::where(['wiki_id' => $wiki->id, 'name' => 'wgReadOnly']);
+        $this->assertSame(1, $wikiSettingReadOnly->count());
+        // and the readonly setting is a non empty string (important for mediawiki)
+        $this->assertTrue(strlen($wikiSettingReadOnly->first()->value) > 0);
 
         // A queryservice namespace will be assigned to this Wiki
         // TODO

--- a/tests/data/example-wiki-details.json
+++ b/tests/data/example-wiki-details.json
@@ -48,6 +48,10 @@
       "wiki_id": 1,
       "created_at": "2022-01-18T15:33:12.000000Z",
       "updated_at": "2022-01-18T15:33:19.000000Z"
+    },
+    {
+      "name": "wgReadOnly",
+      "value": "Read only due to ongoing migration"
     }
   ]
 }


### PR DESCRIPTION
This PR just adds a test case for the MigrationWikiCreateJob, that makes sure, that setting the readOnly setting to a non-empty string works.