### PR TITLE
Make elasticsearch jobs "retryable"

### DIFF
--- a/app/Jobs/CirrusSearch/CirrusSearchJob.php
+++ b/app/Jobs/CirrusSearch/CirrusSearchJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs\CirrusSearch;
 
+use Illuminate\Support\Facades\Log;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use App\WikiSetting;
 use App\Http\Curl\HttpRequest;
@@ -61,6 +62,12 @@ abstract class CirrusSearchJob extends Job implements ShouldBeUnique
             $this->fail( new \RuntimeException($this->apiModule() . ' call for '.$this->wikiId.' was triggered but not WikiDb available') );
             $this->setting->update( [  'value' => false  ] );
             return;
+        }
+
+        // make sure the Elasticsearch is enabled for mediawiki
+        if( !$this->setting->value ) {
+            Log::info(__METHOD__ . ": {$this->wiki->domain}: Enabling setting " . WikiSetting::wwExtEnableElasticSearch);
+            $this->setting->update( [  'value' => true  ] );
         }
         
         $request->setOptions(

--- a/app/Jobs/CirrusSearch/ElasticSearchIndexInit.php
+++ b/app/Jobs/CirrusSearch/ElasticSearchIndexInit.php
@@ -12,7 +12,8 @@ class ElasticSearchIndexInit extends CirrusSearchJob
 
     private function logFailureAndDisable(): void {
         $this->setting->update( [  'value' => false  ] );
-        Log::warning( __METHOD__ . ": Failed initializing elasticsearch. Disabling the setting." );
+        Log::warning( __METHOD__ . ": {$this->wiki->domain}: Failed initializing elasticsearch. Disabling the setting." );
+
     }
 
     public function handleResponse( string $rawResponse, $error ): void
@@ -46,7 +47,7 @@ class ElasticSearchIndexInit extends CirrusSearchJob
             $enableElasticSearchFeature = true;
         } else {
 
-            Log::error(__METHOD__ . ": Job finished but didn't create or update, something is weird");
+            Log::error(__METHOD__ . ": {$this->wiki->domain} Job finished but didn't create or update, something is weird");
             $this->fail( new \RuntimeException($this->apiModule() . ' call for '.$this->wikiId.' was not successful:' . $rawResponse ) );
         }
 

--- a/app/Jobs/CirrusSearch/ForceSearchIndex.php
+++ b/app/Jobs/CirrusSearch/ForceSearchIndex.php
@@ -59,10 +59,10 @@ class ForceSearchIndex extends CirrusSearchJob
 
         if ( count($successMatches) === 2 && is_numeric($successMatches[1][0]) ) {
             $numIndexedPages = intVal($successMatches[1][0]);
-            Log::info(__METHOD__ . ": Finished batch! Indexed ${numIndexedPages} pages. From id {$this->fromId} to {$this->toId}");
+            Log::info(__METHOD__ . ": {$this->wiki->domain}: Finished batch! Indexed ${numIndexedPages} pages. From id {$this->fromId} to {$this->toId}");
         } else {
             dd($successMatches);
-            Log::error(__METHOD__ . ": Job finished but did not contain the expected output.");
+            Log::error(__METHOD__ . ": {$this->wiki->domain}: Job finished but did not contain the expected output.");
             $this->fail( new \RuntimeException($this->apiModule() . ' call for '.$this->wikiId.' was not successful:' . $rawResponse ) );
         }
     }

--- a/app/Jobs/CirrusSearch/QueueSearchIndexBatches.php
+++ b/app/Jobs/CirrusSearch/QueueSearchIndexBatches.php
@@ -63,7 +63,7 @@ class QueueSearchIndexBatches extends CirrusSearchJob
         // if there are no pages to index, just exit now.
         if( !$this->isSuccessful($response) && 
             is_array($output) && count($output) == 1 && $output[0] == "Couldn't find any pages to index.  fromId =  =  = toId." ) {
-            Log::warning(__METHOD__ . ": ForceSearchIndex could not find any pages to index. " . $rawResponse);
+            Log::warning(__METHOD__ . ": {$this->wiki->domain}: ForceSearchIndex could not find any pages to index. " . $rawResponse);
             return;
         }
 
@@ -76,7 +76,7 @@ class QueueSearchIndexBatches extends CirrusSearchJob
         try {
             $batches = $this->convertToBatch( $output );
         } catch (\RuntimeException $e) {
-            Log::error(__METHOD__ . ": Failed to convert command output into batched commands: " . $rawResponse);
+            Log::error(__METHOD__ . ": {$this->wiki->domain}: Failed to convert command output into batched commands: " . $rawResponse);
             $this->fail($e);
             return;
         }
@@ -89,7 +89,7 @@ class QueueSearchIndexBatches extends CirrusSearchJob
 
         } else {
 
-            Log::error(__METHOD__ . ": Job finished but didn't create any batches, something is weird");
+            Log::error(__METHOD__ . ": {$this->wiki->domain}: Job finished but didn't create any batches, something is weird");
             $this->fail( new \RuntimeException($this->apiModule() . ' call for '.$this->wikiId.' was not successful:' . $rawResponse ) );
         }
 


### PR DESCRIPTION
CirrusSearch jobs will not be retryable using commands like

`php artisan queue:retry all`

since the setting gets disabled if init failed.

adds more logging for elasticsearch jobs