### PR TITLE
Disable elasticsearch for new wikis by default

### DIFF
--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -14,4 +14,6 @@ return [
     'platform_summary_inactive_threshold' => env('WBSTACK_SUMMARY_INACTIVE_THRESHOLD', 60 * 60 * 24 * 90),
 
     'elasticsearch_host' => env('ELASTICSEARCH_HOST', false),
+    'elasticsearch_enabled_by_default' => env('WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT', false),
+
 ];


### PR DESCRIPTION
This adds the config parameter `elasticsearch_enabled_by_default`
to control if the feature is enabled for newly created wikis or not.

This also refactors one test to make this support both behaviors.

Bug: T314937