### PR TITLE
test: run passport:install in the context of tests instead of globally

### DIFF
--- a/.github/workflows/composer.test.yml
+++ b/.github/workflows/composer.test.yml
@@ -43,7 +43,6 @@ jobs:
 
     - name: Setup - Other things
       run: |
-        docker-compose exec -T api php artisan passport:install
         docker-compose exec -T api php artisan key:generate
 
     - name: PHPUnit

--- a/tests/Routes/Auth/LoginTest.php
+++ b/tests/Routes/Auth/LoginTest.php
@@ -14,6 +14,12 @@ class LoginTest extends TestCase
     use OptionsRequestAllowed;
     use DatabaseTransactions;
 
+    public function setUp (): void
+    {
+        parent::setUp();
+        $this->artisan('passport:install', ['--no-interaction' => true]);
+    }
+
     public function testLoginFail_noExistingUser()
     {
         // This random user probably doesn't exist in the db


### PR DESCRIPTION
Working on #603 I noticed using the `RefreshDatabase` trait in tests that are run before the `LoginTest` suite will make the `LoginTest`s fail.

This seems to caused by the fact that `RefreshDatabase` wipes the tokens from the database that have been written in the test setup, making subsequent tests fail that rely on this token.

Instead, this PR moves token creation into the test that actually uses the token, making sure it's present. In consequence this also means, that when introducing new tests that also use such a token, they will need to run the same pre-test setup.

See: https://stackoverflow.com/questions/50113508/how-to-test-authentication-via-api-with-laravel-passport/50243105#50243105