### PR TITLE
fix(jobs): prevent polling job from hitting default timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # api
 
-## 8x.12.0 - TBD
+## 8x.12.1 - 12 June 2023
+- Raise timeout values for polling wikis for pending jobs
+
+## 8x.12.0 - 01 June 2023
 - Poll wikis for pending MediaWiki jobs and create Kubernetes jobs to process them if needed
 
 ## 8x.11.1 - 18 April 2023

--- a/app/Jobs/PollForMediaWikiJobsJob.php
+++ b/app/Jobs/PollForMediaWikiJobsJob.php
@@ -5,9 +5,11 @@ namespace App\Jobs;
 use App\Wiki;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
 
-class PollForMediaWikiJobsJob extends Job
+class PollForMediaWikiJobsJob extends Job implements ShouldBeUnique
 {
+    public $timeout = 3600;
     public function handle (): void
     {
         $allWikiDomains = Wiki::all()->pluck('domain');


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T330389

Polling all wikis serially seems to be rather slow, so the default timeout of 90s seems to be too low for proudction. Instead, allow the job to run for over an hour.