### PR TITLE
fix(mw-jobs): polling job does not implement ShouldQueue, making it run in parallel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.12.2 - 13 June 2023
+- Make sure job for polling wikis does queue properly
+
 ## 8x.12.1 - 12 June 2023
 - Raise timeout values for polling wikis for pending jobs
 

--- a/app/Jobs/PollForMediaWikiJobsJob.php
+++ b/app/Jobs/PollForMediaWikiJobsJob.php
@@ -6,8 +6,9 @@ use App\Wiki;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Contracts\Queue\ShouldQueue;
 
-class PollForMediaWikiJobsJob extends Job implements ShouldBeUnique
+class PollForMediaWikiJobsJob extends Job implements ShouldQueue, ShouldBeUnique
 {
     public $timeout = 3600;
     public function handle (): void


### PR DESCRIPTION
It looks as if production runs these jobs in parallel on both queue replicas:

```
[2023-06-13 14:46:06][Jypa1t3JjZmzd3XXdUw4Uj2XSfH3w7Su] Processing: App\Jobs\PollForMediaWikiJobsJob
```
and
```
[2023-06-13 14:46:05][jcnOHbzKj2dqNi90MWk13hWhl0VQxKHf] Processing: App\Jobs\PollForMediaWikiJobsJob
```

It's not entirely clear [from the documentation](https://laravel.com/docs/8.x/queues#unique-jobs), but it seems plausible that adding the `ShouldQueue` interface to the class will help.