### PR TITLE
fix(mw-jobs): schedule polling job without overlapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.12.3 - 13 June 2023
+- Schedule job for polling wikis without overlap
+
 ## 8x.12.2 - 13 June 2023
 - Make sure job for polling wikis does queue properly
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -45,7 +45,7 @@ class Kernel extends ConsoleKernel
         // Schedule site stat updates for each wiki and platform-summary
         $schedule->command('schedule:stats')->daily();
 
-        $schedule->job(new PollForMediaWikiJobsJob)->everyMinute();
+        $schedule->job(new PollForMediaWikiJobsJob)->name('Poll for MediaWiki Jobs')->withoutOverlapping();
     }
 
     /**


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T339071

I got this working locally (adding a `sleep(100)` to the job itself), but it's very hard to test and not entirely clear to me what happens under the hood. We might need to clear the current queue in production before deploying this.