### PR TITLE
feat(wiki): force lower case domain names on creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.13.0 - 22 June 2023
+- Force lowercase domain names on wiki creation
+
 ## 8x.12.4 - 19 June 2023
 - Reenable work done in polling job
 

--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -32,7 +32,7 @@ class WikiController extends Controller
     public function create(Request $request): \Illuminate\Http\Response
     {
         $user = $request->user();
-        $submittedDomain = $request->input('domain');
+        $submittedDomain = strtolower($request->input('domain'));
         
         $validator = $this->domainValidator->validate( $submittedDomain );
         $isSubdomain = $this->isSubDomain($submittedDomain);

--- a/tests/Routes/Wiki/CreateTest.php
+++ b/tests/Routes/Wiki/CreateTest.php
@@ -51,7 +51,7 @@ class CreateTest extends TestCase
             'POST',
             $this->route,
             [
-                'domain' => 'derp.com',
+                'domain' => 'dErP.com',
                 'sitename' => 'merp',
                 'username' => 'AdminBoss'
             ]
@@ -82,7 +82,6 @@ class CreateTest extends TestCase
             WikiSetting::where( [ 'name' => WikiSetting::wwExtEnableElasticSearch, 'value' => $elasticSearchEnabledForNewWikis, 'wiki_id' => $id ] )->count()
         );
     }
-
 
     public function createProvider() {
 


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T339860

I was able to test this locally, both with subdomains as well as custom domain names.