### PR TITLE
feat(platform-stats): provide number of recently created wikis and users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.14.0 - TBD
+- Collect signup rate metrics with platform summary job
+
 ## 8x.13.0 - 22 June 2023
 - Force lowercase domain names on wiki creation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # api
 
-## 8x.14.0 - TBD
+## 8x.14.0 - 04 July 2023
 - Collect signup and wiki creation rate metrics with platform summary job
 
 ## 8x.13.0 - 22 June 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # api
 
 ## 8x.14.0 - TBD
-- Collect signup rate metrics with platform summary job
+- Collect signup and wiki creation rate metrics with platform summary job
 
 ## 8x.13.0 - 22 June 2023
 - Force lowercase domain names on wiki creation

--- a/app/Jobs/PlatformStatsSummaryJob.php
+++ b/app/Jobs/PlatformStatsSummaryJob.php
@@ -27,12 +27,12 @@ use Illuminate\Support\Facades\App;
 class PlatformStatsSummaryJob extends Job
 {
     private $inactiveThreshold;
-    private $signupRanges;
+    private $creationRanges;
 
     private $platformSummaryStatsVersion = "v1";
     public function __construct() {
         $this->inactiveThreshold = Config::get('wbstack.platform_summary_inactive_threshold');
-        $this->signupRanges = Config::get('wbstack.platform_summary_signup_ranges');
+        $this->creationRanges = Config::get('wbstack.platform_summary_creation_ranges');
     }
 
     private function isNullOrEmpty( $value ): bool {
@@ -45,9 +45,9 @@ class PlatformStatsSummaryJob extends Job
         $activeWikis = [];
         $inactive = [];
         $emptyWikis = [];
-        $newWikis = [];
-        foreach ($this->signupRanges as $range) {
-            $newWikis[$range] = [];
+        $createdWikis = [];
+        foreach ($this->creationRanges as $range) {
+            $createdWikis[$range] = [];
         }
         $nonDeletedStats = [];
 
@@ -62,10 +62,10 @@ class PlatformStatsSummaryJob extends Job
             }
 
             $createdAt = new Carbon($wiki->created_at);
-            foreach ($newWikis as $range=>$matches) {
+            foreach ($createdWikis as $range=>$matches) {
                 $lookback = new \DateInterval($range);
                 if ($createdAt >= $now->clone()->sub($lookback)) {
-                    $newWikis[$range][] = $wiki;
+                    $createdWikis[$range][] = $wiki;
                 }
             }
 
@@ -125,8 +125,8 @@ class PlatformStatsSummaryJob extends Job
             'total_non_deleted_edits' => $totalNonDeletedEdits,
         ];
 
-        foreach ($newWikis as $range=>$items) {
-            $result['new_wikis_'.$range] = count($items);
+        foreach ($createdWikis as $range=>$items) {
+            $result['wikis_created_'.$range] = count($items);
         }
 
         return $result;

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -12,8 +12,8 @@ return [
     'wiki_max_per_user' => env('WBSTACK_MAX_PER_USER', false),
 
     'platform_summary_inactive_threshold' => env('WBSTACK_SUMMARY_INACTIVE_THRESHOLD', 60 * 60 * 24 * 90),
-    'platform_summary_signup_ranges' => array_filter(
-        explode(',', env('WBSTACK_SUMMARY_SIGNUP_RANGES', '')),
+    'platform_summary_creation_ranges' => array_filter(
+        explode(',', env('WBSTACK_SUMMARY_CREATION_RANGES', '')),
         function ($item) { return $item !== ''; }
     ),
 

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -12,8 +12,8 @@ return [
     'wiki_max_per_user' => env('WBSTACK_MAX_PER_USER', false),
 
     'platform_summary_inactive_threshold' => env('WBSTACK_SUMMARY_INACTIVE_THRESHOLD', 60 * 60 * 24 * 90),
-    'platform_summary_creation_ranges' => array_filter(
-        explode(',', env('WBSTACK_SUMMARY_CREATION_RANGES', '')),
+    'platform_summary_creation_rate_ranges' => array_filter(
+        explode(',', env('WBSTACK_SUMMARY_CREATION_RATE_RANGES', '')),
         function ($item) { return $item !== ''; }
     ),
 

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -13,8 +13,7 @@ return [
 
     'platform_summary_inactive_threshold' => env('WBSTACK_SUMMARY_INACTIVE_THRESHOLD', 60 * 60 * 24 * 90),
     'platform_summary_creation_rate_ranges' => array_filter(
-        explode(',', env('WBSTACK_SUMMARY_CREATION_RATE_RANGES', '')),
-        function ($item) { return $item !== ''; }
+        explode(',', env('WBSTACK_SUMMARY_CREATION_RATE_RANGES', ''))
     ),
 
     'elasticsearch_host' => env('ELASTICSEARCH_HOST', false),

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -12,6 +12,7 @@ return [
     'wiki_max_per_user' => env('WBSTACK_MAX_PER_USER', false),
 
     'platform_summary_inactive_threshold' => env('WBSTACK_SUMMARY_INACTIVE_THRESHOLD', 60 * 60 * 24 * 90),
+    'platform_summary_signup_ranges' => explode(',', env('WBSTACK_SUMMARY_SIGNUP_RANGES', 'PT24H,P30D')),
 
     'elasticsearch_host' => env('ELASTICSEARCH_HOST', false),
     'elasticsearch_enabled_by_default' => env('WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT', false),

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -12,7 +12,10 @@ return [
     'wiki_max_per_user' => env('WBSTACK_MAX_PER_USER', false),
 
     'platform_summary_inactive_threshold' => env('WBSTACK_SUMMARY_INACTIVE_THRESHOLD', 60 * 60 * 24 * 90),
-    'platform_summary_signup_ranges' => explode(',', env('WBSTACK_SUMMARY_SIGNUP_RANGES', 'PT24H,P30D')),
+    'platform_summary_signup_ranges' => array_filter(
+        explode(',', env('WBSTACK_SUMMARY_SIGNUP_RANGES', '')),
+        function ($item) { return $item !== ''; }
+    ),
 
     'elasticsearch_host' => env('ELASTICSEARCH_HOST', false),
     'elasticsearch_enabled_by_default' => env('WBSTACK_ELASTICSEARCH_ENABLED_BY_DEFAULT', false),

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,6 @@
     <env name="CACHE_DRIVER" value="array"/>
     <env name="QUEUE_CONNECTION" value="sync"/>
     <env name="PLATFORM_MW_BACKEND_HOST" value="mediawiki-139-app-backend.default.svc.cluster.default"/>
-    <env name="WBSTACK_SUMMARY_SIGNUP_RANGES" value="PT24H,P30D"/>
+    <env name="WBSTACK_SUMMARY_CREATION_RANGES" value="PT24H,P30D"/>
   </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,5 +15,6 @@
     <env name="CACHE_DRIVER" value="array"/>
     <env name="QUEUE_CONNECTION" value="sync"/>
     <env name="PLATFORM_MW_BACKEND_HOST" value="mediawiki-139-app-backend.default.svc.cluster.default"/>
+    <env name="WBSTACK_SUMMARY_SIGNUP_RANGES" value="PT24H,P30D"/>
   </php>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -15,6 +15,6 @@
     <env name="CACHE_DRIVER" value="array"/>
     <env name="QUEUE_CONNECTION" value="sync"/>
     <env name="PLATFORM_MW_BACKEND_HOST" value="mediawiki-139-app-backend.default.svc.cluster.default"/>
-    <env name="WBSTACK_SUMMARY_CREATION_RANGES" value="PT24H,P30D"/>
+    <env name="WBSTACK_SUMMARY_CREATION_RATE_RANGES" value="PT24H,P30D"/>
   </php>
 </phpunit>

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -82,13 +82,12 @@ class PlatformStatsSummaryJobTest extends TestCase
 
         $job = new PlatformStatsSummaryJob();
         $job->setJob($mockJob);
-        
-        $testWikis = [
-            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki1.com' ] ),
-            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki2.com' ] ),
-            Wiki::factory()->create( [ 'deleted_at' => Carbon::now()->subDays(90)->timestamp, 'domain' => 'wiki3.com' ] ),
-            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki4.com' ] )
 
+        $testWikis = [
+            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki1.com', 'created_at' => Carbon::now()->subMinutes(4)->timestamp ] ),
+            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki2.com', 'created_at' => Carbon::now()->subHours(72)->timestamp ] ),
+            Wiki::factory()->create( [ 'deleted_at' => Carbon::now()->subDays(90)->timestamp, 'domain' => 'wiki3.com', 'created_at' => Carbon::now()->subHours(72)->timestamp ] ),
+            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki4.com', 'created_at' => Carbon::now()->subYears(6)->timestamp ] )
         ];
 
         foreach($testWikis as $wiki) {
@@ -99,7 +98,7 @@ class PlatformStatsSummaryJobTest extends TestCase
                 'version' => 'asdasdasdas',
                 'prefix' => 'asdasd',
                 'wiki_id' => $wiki->id
-            ]);  
+            ]);
         }
         $stats = [
             [   // inactive
@@ -145,10 +144,10 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "platform_summary_version" => "v1"
             ],
         ];
-          
+
 
        $groups =  $job->prepareStats($stats, $testWikis);
-    
+
        $this->assertEquals(
             [
                 "total" => 4,
@@ -160,9 +159,11 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "total_non_deleted_active_users" => 1,
                 "total_non_deleted_pages" => 2,
                 "total_non_deleted_edits" => 1,
-                "platform_summary_version" => "v1"
+                "platform_summary_version" => "v1",
+                "new_wikis_PT24H" => 1,
+                "new_wikis_P30D" => 2,
             ],
-            $groups, 
+            $groups,
         );
     }
 

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -145,8 +145,13 @@ class PlatformStatsSummaryJobTest extends TestCase
             ],
         ];
 
+        $users = [
+            User::factory()->create([ "created_at" => Carbon::now()->subDays(90)->timestamp ]),
+            User::factory()->create([ "created_at" => Carbon::now()->subHours(1)->timestamp ]),
+            User::factory()->create([ "created_at" => Carbon::now()->subHours(48)->timestamp ]),
+        ];
 
-       $groups =  $job->prepareStats($stats, $testWikis);
+       $groups =  $job->prepareStats($stats, $testWikis, $users);
 
        $this->assertEquals(
             [
@@ -162,6 +167,8 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "platform_summary_version" => "v1",
                 "wikis_created_PT24H" => 1,
                 "wikis_created_P30D" => 2,
+                "users_created_PT24H" => 1,
+                "users_created_P30D" => 2,
             ],
             $groups,
         );

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -160,8 +160,8 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "total_non_deleted_pages" => 2,
                 "total_non_deleted_edits" => 1,
                 "platform_summary_version" => "v1",
-                "new_wikis_PT24H" => 1,
-                "new_wikis_P30D" => 2,
+                "wikis_created_PT24H" => 1,
+                "wikis_created_P30D" => 2,
             ],
             $groups,
         );

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -42,6 +42,7 @@ class PlatformStatsSummaryJobTest extends TestCase
     }
 
     private function seedWikis() {
+        $this->wikis = [];
         $manager = $this->app->make('db');
         for($n = 0; $n < $this->numWikis; $n++ ) {
 

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -29,12 +29,11 @@ class PlatformStatsSummaryJobTest extends TestCase
         for($n = 0; $n < $this->numWikis; $n++ ) {
             DB::connection('mysql')->getPdo()->exec("DROP DATABASE IF EXISTS {$this->db_name}{$n};");
         }
-        $this->seedWikis();
-        $this->manager = $this->app->make('db');
+        $this->wikis = [];
     }
 
     protected function tearDown(): void {
-        foreach($this->wikis as $wiki) {
+        foreach ($this->wikis as $wiki) {
             $wiki['wiki']->wikiDb()->forceDelete();
             $wiki['wiki']->forceDelete();
         }
@@ -42,7 +41,6 @@ class PlatformStatsSummaryJobTest extends TestCase
     }
 
     private function seedWikis() {
-        $this->wikis = [];
         $manager = $this->app->make('db');
         for($n = 0; $n < $this->numWikis; $n++ ) {
 
@@ -65,6 +63,7 @@ class PlatformStatsSummaryJobTest extends TestCase
     }
     public function testQueryGetsStats()
     {
+        $this->seedWikis();
         $manager = $this->app->make('db');
 
         $mockJob = $this->createMock(Job::class);
@@ -89,7 +88,6 @@ class PlatformStatsSummaryJobTest extends TestCase
             Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki2.com' ] ),
             Wiki::factory()->create( [ 'deleted_at' => Carbon::now()->subDays(90)->timestamp, 'domain' => 'wiki3.com' ] ),
             Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki4.com' ] )
-
         ];
 
         foreach($testWikis as $wiki) {


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T335961

This provides any configured number of additional metrics from the `PlatformStatsJob`. Ranges are added by passing a valid `TimeInterval` string to `WBSTACK_SUMMARY_CREATION_RATE_RANGES`.