### PR TITLE
feat: report exception instead of logging when throttling account creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # api
 
-## 8x.15.1 - 13 July 2023
+## 8x.15.1 - 24 July 2023
 - Report Exception instead of logging when throttling account creation
 
 ## 8x.15.0 - 13 July 2023

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.15.1 - 13 July 2023
+- Report Exception instead of logging when throttling account creation
+
 ## 8x.15.0 - 13 July 2023
 - Throttle user signup
 

--- a/app/Http/Middleware/ThrottleSignup.php
+++ b/app/Http/Middleware/ThrottleSignup.php
@@ -6,7 +6,6 @@ use Closure;
 use Carbon\Carbon;
 use App\User;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Log;
 
 class ThrottleSignup
 {
@@ -19,7 +18,7 @@ class ThrottleSignup
         $lookback = Carbon::now()->sub(new \DateInterval($range));
         $recentSignups = User::where('created_at', '>=', $lookback)->count();
         if ($recentSignups >= intval($limit)) {
-            Log::warning("WARN_SIGNUP_THROTTLED: Given limit of '$limit' in range '$range' was exceeded, attempted account creation was blocked.");
+            report("Attempted account creation was blocked because given limits were exceeded.");
             return response()->json(
                 ["errors" => "Due to high load, we're currently not able to create an account for you. Please try again tomorrow or reach out through our contact page."],
                 503


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T335963

This is a tentative PR for when we wanted to try using Error Reporting instead of Log Metrics. 