### PR TITLE
feat(queue): Add failed job backoff configuration

### DIFF
--- a/app/Jobs/Job.php
+++ b/app/Jobs/Job.php
@@ -6,6 +6,7 @@ use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Config;
 
 abstract class Job implements ShouldQueue
 {
@@ -20,4 +21,9 @@ abstract class Job implements ShouldQueue
     |
     */
     use InteractsWithQueue, Queueable, SerializesModels;
+
+    public function backoff(): array
+    {
+        return Config::get('queue.backoff');
+    }
 }

--- a/config/queue.php
+++ b/config/queue.php
@@ -84,5 +84,5 @@ return [
         'table' => 'failed_jobs',
     ],
 
-    'backoff' => explode(',', env('QUEUE_BACKOFF', '10,60,300,900,1500')), // 10s, 1m, 5m, 15m, 30m
+    'backoff' => explode(',', env('QUEUE_BACKOFF', '')),
 ];

--- a/config/queue.php
+++ b/config/queue.php
@@ -84,4 +84,5 @@ return [
         'table' => 'failed_jobs',
     ],
 
+    'backoff' => explode(',', env('QUEUE_BACKOFF', '10,60,300,900,1500')), // 10s, 1m, 5m, 15m, 30m
 ];


### PR DESCRIPTION
Currently failed jobs will be retried 5 times[1]. This adds job backoff configuration as suggested [here](https://phabricator.wikimedia.org/T325894#9023530), so that failed retries will happen with incremental delays:
- 10 seconds
- 1 minute
- 5 minutes
- 15 minutes
- 30 minutes

[1] https://github.com/wbstack/api/blob/main/start.sh#L20

Draft status because I couldn't make this work on my local cluster yet.