### PR TITLE
feat(queue): `report()` on failed jobs

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Queue\Events\JobFailed;
 use App\Http\Curl\CurlRequest;
 use App\Http\Curl\HttpRequest;
 
@@ -31,6 +33,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot()
     {
-        //
+        Queue::failing(function (JobFailed $event) {
+            $name = data_get($event->job->payload(), 'data.commandName');
+            $wrappedException = new \Exception("Executing Job '$name' failed.", 1, $event->exception);
+            report($wrappedException);
+        });
     }
 }


### PR DESCRIPTION
This adds calling the Laravel `report()` helper function [1] as error handling for failed queue'd jobs as per https://phabricator.wikimedia.org/T325894#9023483.

Note: `$event->job->getName();` was changed to `data_get($event->job->payload(), 'data.commandName');`, as the former would always return a constant string for the class `CallQueuedHandler`. See https://github.com/illuminate/queue/blob/8.x/Queue.php#L143

[1] https://laravel.com/docs/8.x/helpers#method-report