### PR TITLE
refactor(MediawikiInitJob): remove fail() calls

### DIFF
--- a/app/Jobs/MediawikiInit.php
+++ b/app/Jobs/MediawikiInit.php
@@ -48,29 +48,17 @@ class MediawikiInit extends Job
         $request->close();
 
         if ($err) {
-            $this->fail(
-                new \RuntimeException('curl error for '.$this->wikiDomain.': '.$err)
-            );
-
-            return; //safegaurd
+            throw new \RuntimeException('curl error for '.$this->wikiDomain.': '.$err);
         }
 
         $response = json_decode($rawResponse, true);
 
         if ( !is_array($response) || !array_key_exists('wbstackInit', $response) ) {
-            $this->fail(
-                new \RuntimeException('wbstackInit call for '.$this->wikiDomain.'. No wbstackInit key in response: '.$rawResponse)
-            );
-
-            return; //safegaurd
+            throw new \RuntimeException('wbstackInit call for '.$this->wikiDomain.'. No wbstackInit key in response: '.$rawResponse);
         }
 
         if ($response['wbstackInit']['success'] == 0) {
-            $this->fail(
-                new \RuntimeException('wbstackInit call for '.$this->wikiDomain.' was not successful:'.$rawResponse)
-            );
-
-            return; //safegaurd
+            throw new \RuntimeException('wbstackInit call for '.$this->wikiDomain.' was not successful:'.$rawResponse);
         }
         // Otherwise there was success (and we could get the userId if we wanted...
     }

--- a/tests/Jobs/MediawikiInitTest.php
+++ b/tests/Jobs/MediawikiInitTest.php
@@ -82,11 +82,11 @@ class MediawikiInitTest extends TestCase
 
         $mockJob = $this->createMock(Job::class);
 
-        $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage($mockExceptionMessage);
-
         $job = new MediawikiInit( $this->wikiDomain, $this->username, $this->email );
         $job->setJob($mockJob);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($mockExceptionMessage);
         $job->handle($request);
     }
 }

--- a/tests/Jobs/MediawikiInitTest.php
+++ b/tests/Jobs/MediawikiInitTest.php
@@ -76,8 +76,9 @@ class MediawikiInitTest extends TestCase
     public function testFatalErrorIsHandled()
     {
         $mockResponse = 'oh no';
-        $mockExceptionMessage = 'wbstackInit call for some.domain.com. No wbstackInit key in response: ' . $mockResponse;
         $request = $this->getMockRequest($mockResponse);
+
+        $mockExceptionMessage = 'wbstackInit call for some.domain.com. No wbstackInit key in response: ' . $mockResponse;
 
         $mockJob = $this->createMock(Job::class);
 

--- a/tests/Jobs/MediawikiInitTest.php
+++ b/tests/Jobs/MediawikiInitTest.php
@@ -78,7 +78,7 @@ class MediawikiInitTest extends TestCase
         $mockResponse = 'oh no';
         $request = $this->getMockRequest($mockResponse);
 
-        $mockExceptionMessage = 'wbstackInit call for some.domain.com. No wbstackInit key in response: ' . $mockResponse;
+        $expectedExceptionMessage = 'wbstackInit call for some.domain.com. No wbstackInit key in response: ' . $mockResponse;
 
         $mockJob = $this->createMock(Job::class);
 
@@ -86,7 +86,7 @@ class MediawikiInitTest extends TestCase
         $job->setJob($mockJob);
 
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessage($mockExceptionMessage);
+        $this->expectExceptionMessage($expectedExceptionMessage);
         $job->handle($request);
     }
 }

--- a/tests/Jobs/MediawikiInitTest.php
+++ b/tests/Jobs/MediawikiInitTest.php
@@ -76,22 +76,16 @@ class MediawikiInitTest extends TestCase
     public function testFatalErrorIsHandled()
     {
         $mockResponse = 'oh no';
-        $mockException = new \RuntimeException('wbstackInit call for some.domain.com. No wbstackInit key in response: ' . $mockResponse);
-
+        $mockExceptionMessage = 'wbstackInit call for some.domain.com. No wbstackInit key in response: ' . $mockResponse;
         $request = $this->getMockRequest($mockResponse);
 
         $mockJob = $this->createMock(Job::class);
 
-        $caughtException = null;
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage($mockExceptionMessage);
 
-        try {
-            $job = new MediawikiInit( $this->wikiDomain, $this->username, $this->email );
-            $job->setJob($mockJob);
-            $job->handle($request);
-        } catch(\RuntimeException $e) {
-            $caughtException = $e;
-        }
-
-        $this->assertEquals($caughtException, $mockException);
+        $job = new MediawikiInit( $this->wikiDomain, $this->username, $this->email );
+        $job->setJob($mockJob);
+        $job->handle($request);
     }
 }

--- a/tests/Jobs/MediawikiInitTest.php
+++ b/tests/Jobs/MediawikiInitTest.php
@@ -76,16 +76,22 @@ class MediawikiInitTest extends TestCase
     public function testFatalErrorIsHandled()
     {
         $mockResponse = 'oh no';
+        $mockException = new \RuntimeException('wbstackInit call for some.domain.com. No wbstackInit key in response: ' . $mockResponse);
 
         $request = $this->getMockRequest($mockResponse);
 
         $mockJob = $this->createMock(Job::class);
-        $mockJob->expects($this->once())
-                ->method('fail')
-                ->with(new \RuntimeException('wbstackInit call for some.domain.com. No wbstackInit key in response: ' . $mockResponse ));
 
-        $job = new MediawikiInit( $this->wikiDomain, $this->username, $this->email );
-        $job->setJob($mockJob);
-        $job->handle($request);
+        $caughtException = null;
+
+        try {
+            $job = new MediawikiInit( $this->wikiDomain, $this->username, $this->email );
+            $job->setJob($mockJob);
+            $job->handle($request);
+        } catch(\RuntimeException $e) {
+            $caughtException = $e;
+        }
+
+        $this->assertEquals($caughtException, $mockException);
     }
 }


### PR DESCRIPTION
https://phabricator.wikimedia.org/T325894

Our Laravel Jobs won't get retried if we mark them as `failed` via `$this->fail()` if erros occur during the jobs processing.

This PR removes unwraps those calls and throws the Exceptions for the `MediawikiInit` Job. This way, the job gets retried in case it fails.

For more effectiveness, this should not be released before https://github.com/wbstack/api/pull/621

