### PR TITLE
chore(jobs): stats collection at 7AM does not conflict with backup schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.17.1 - TBD
+- Reschedule stats collection job to 7AM
+
 ## 8x.17.0 - 01 August 2023
 - Support arbitrary number of ElasticSearch clusters
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -11,9 +11,6 @@ use App\Jobs\SandboxCleanupJob;
 use App\Jobs\PollForMediaWikiJobsJob;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
-use App\Jobs\PlatformStatsSummaryJob;
-use App\Wiki;
-use App\Jobs\SiteStatsUpdateJob;
 
 class Kernel extends ConsoleKernel
 {
@@ -43,7 +40,7 @@ class Kernel extends ConsoleKernel
         $schedule->job(new SandboxCleanupJob)->everyFifteenMinutes();
 
         // Schedule site stat updates for each wiki and platform-summary
-        $schedule->command('schedule:stats')->daily();
+        $schedule->command('schedule:stats')->dailyAt('7:00');
 
         $schedule->job(new PollForMediaWikiJobsJob)->everyFifteenMinutes();
     }


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T317980