### PR TITLE
feat(console): add Command for changing user mail

### DIFF
--- a/app/Console/Commands/User/ChangeEmail.php
+++ b/app/Console/Commands/User/ChangeEmail.php
@@ -14,8 +14,8 @@ class ChangeEmail extends Command
 
     public function handle(): int
     {
-        $emailOld = $this->argument('--from');
-        $emailNew = $this->argument('--to');
+        $emailOld = $this->option('from');
+        $emailNew = $this->option('to');
 
         $user = User::whereEmail($emailOld)->first();
 

--- a/app/Console/Commands/User/ChangeEmail.php
+++ b/app/Console/Commands/User/ChangeEmail.php
@@ -21,7 +21,7 @@ class ChangeEmail extends Command
             if ($user) {
                 $this->line("Found a user for '$emailOld'");
             } else {
-                $this->warn("Did not find a user for '$emailOld' Please try again.");
+                $this->warn("Did not find a user for '$emailOld'. Please try again.");
             }
         } while(!$user);
 

--- a/app/Console/Commands/User/ChangeEmail.php
+++ b/app/Console/Commands/User/ChangeEmail.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands\User;
+
+use App\User;
+use Illuminate\Console\Command;
+use App\Jobs\UserVerificationCreateTokenAndSendJob;
+
+class ChangeEmail extends Command
+{
+    protected $signature = 'wbs-user:change-email';
+
+    protected $description = 'Change e-mail address for user';
+
+    public function handle(): int
+    {
+        do {
+            $emailOld = $this->ask('Current user address');
+            $user = User::whereEmail($emailOld)->first();
+
+            if ($user) {
+                $this->line("Found a user for '$emailOld'");
+            } else {
+                $this->warn("Did not find a user for '$emailOld' Please try again.");
+            }
+        } while(!$user);
+
+        do {
+            $emailNew = $this->ask('New user address');
+            
+            if ($emailNew == $emailOld) {
+                $this->warn("New email matches current email. Please provide a different address.");
+            }
+        } while ($emailNew == $emailOld);
+
+        if (! $this->confirm("Confirm: changing user mail address '$emailOld' to '$emailNew'")) {
+            $this->warn("Aborted changing user email address");
+            return 1;
+        }
+
+        $user->email = $emailNew;
+        $user->verified = false;
+
+        if ($user->save()) {
+            UserVerificationCreateTokenAndSendJob::newForReverification($user)->handle();
+
+            $this->info("Successfully changed user email '$emailOld' to '$emailNew'");
+            $this->line("Note: a verification mail was sent to the new address ('$emailNew').");
+
+            return 0;
+        } else {
+            $this->error("Failed to change user email '$emailOld' to '$emailNew'");
+            return 2;
+        }
+    }
+}

--- a/tests/Commands/User/ChangeEmailTest.php
+++ b/tests/Commands/User/ChangeEmailTest.php
@@ -14,10 +14,15 @@ class ChangeEmailTest extends TestCase
 
     const EMAIL_OLD = 'old@example.com';
     const EMAIL_NEW = 'new@example.com';
-    protected function createUser($email) {
-        $user = new User(['email' => $email, 'password' => 'worldsstrongestpassword']);
+    
+    private function createUser($email)
+    {
+        $user = new User([
+            'email' => $email,
+            'password' => 'worldsstrongestpassword'
+        ]);
         $user->save();
-
+        
         return $user;
     }
 
@@ -60,7 +65,7 @@ class ChangeEmailTest extends TestCase
 
         $this->assertSame($oldUser->id, $newUser->id);
         $this->assertSame($newUser->email, self::EMAIL_OLD);
-        $this->assertTrue($newUser->hasVerifiedEmail());
+        $this->assertFalse($newUser->hasVerifiedEmail());
 
         Notification::assertNothingSent();
     }
@@ -82,7 +87,7 @@ class ChangeEmailTest extends TestCase
 
         $this->assertSame($oldUser->id, $newUser->id);
         $this->assertSame($newUser->email, self::EMAIL_OLD);
-        $this->assertTrue($newUser->hasVerifiedEmail());
+        $this->assertFalse($newUser->hasVerifiedEmail());
 
         Notification::assertNothingSent();
     }

--- a/tests/Commands/User/ChangeEmailTest.php
+++ b/tests/Commands/User/ChangeEmailTest.php
@@ -39,7 +39,7 @@ class ChangeEmailTest extends TestCase
 
         $this->assertSame($oldUser->id, $newUser->id);
         $this->assertSame($newUser->email, $emailNew);
-        $this->assertSame($newUser->verified, 0);
+        $this->assertFalse($newUser->hasVerifiedEmail());
 
         Notification::assertSentTo([$newUser], EmailReverificationNotification::class);
     }

--- a/tests/Commands/User/ChangeEmailTest.php
+++ b/tests/Commands/User/ChangeEmailTest.php
@@ -3,14 +3,14 @@
 namespace Tests\Commands;
 
 use App\User;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\Notifications\EmailReverificationNotification;
 use Illuminate\Support\Facades\Notification;
 
 class ChangeEmailTest extends TestCase
 {
-    use DatabaseMigrations;
+    use RefreshDatabase;
 
     public function test()
     {

--- a/tests/Commands/User/ChangeEmailTest.php
+++ b/tests/Commands/User/ChangeEmailTest.php
@@ -24,7 +24,7 @@ class ChangeEmailTest extends TestCase
 
         $this->artisan('wbs-user:change-email')
             ->expectsQuestion('Current user address', $emailNew)
-            ->expectsOutput("Did not find a user for '$emailNew' Please try again.")
+            ->expectsOutput("Did not find a user for '$emailNew'. Please try again.")
             ->expectsQuestion('Current user address', $emailOld)
             ->expectsOutput("Found a user for '$emailOld'")
             ->expectsQuestion('New user address', $emailOld)

--- a/tests/Commands/User/ChangeEmailTest.php
+++ b/tests/Commands/User/ChangeEmailTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Commands;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use App\Notifications\EmailReverificationNotification;
+use Illuminate\Support\Facades\Notification;
+
+class ChangeEmailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test()
+    {
+        Notification::fake();
+
+        $emailOld = 'old@example.com';
+        $emailNew = 'new@example.com';
+
+        $oldUser = new User(['email' => $emailOld, 'password' => 'worldsstrongestpassword']);
+        $oldUser->save();
+
+        $this->artisan('wbs-user:change-email')
+            ->expectsQuestion('Current user address', $emailNew)
+            ->expectsOutput("Did not find a user for '$emailNew' Please try again.")
+            ->expectsQuestion('Current user address', $emailOld)
+            ->expectsOutput("Found a user for '$emailOld'")
+            ->expectsQuestion('New user address', $emailOld)
+            ->expectsOutput("New email matches current email. Please provide a different address.")
+            ->expectsQuestion('New user address', $emailNew)
+            ->expectsConfirmation("Confirm: changing user mail address '$emailOld' to '$emailNew'", "yes")
+            ->expectsOutput("Successfully changed user email '$emailOld' to '$emailNew'")
+            ->expectsOutput("Note: a verification mail was sent to the new address ('$emailNew').")
+            ->assertExitCode(0);
+
+        $newUser = User::firstWhere('email', $emailNew);
+
+        $this->assertSame($oldUser->id, $newUser->id);
+        $this->assertSame($newUser->email, $emailNew);
+        $this->assertSame($newUser->verified, 0);
+
+        Notification::assertSentTo([$newUser], EmailReverificationNotification::class);
+    }
+}

--- a/tests/Commands/User/ChangeEmailTest.php
+++ b/tests/Commands/User/ChangeEmailTest.php
@@ -3,14 +3,14 @@
 namespace Tests\Commands;
 
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 use App\Notifications\EmailReverificationNotification;
 use Illuminate\Support\Facades\Notification;
 
 class ChangeEmailTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseTransactions;
 
     public function test()
     {

--- a/tests/Commands/User/ChangeEmailTest.php
+++ b/tests/Commands/User/ChangeEmailTest.php
@@ -3,14 +3,14 @@
 namespace Tests\Commands;
 
 use App\User;
-use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Tests\TestCase;
 use App\Notifications\EmailReverificationNotification;
 use Illuminate\Support\Facades\Notification;
 
 class ChangeEmailTest extends TestCase
 {
-    use RefreshDatabase;
+    use DatabaseMigrations;
 
     public function test()
     {


### PR DESCRIPTION
I wanted to explore the Laravel Console Commands a bit and changing user mails seemed like a nice test subject for reducing points of failures.

So far the process for doing this is
- manually editing the user field on *production*
  - via a `artisan tinker` session
  - or changing it directly in SQL

The idea is to call the command like
```
php artisan wbs-user:change-mail --from='oldmail@example.com' --to='newmail@example.com'
```

After the change is made to the user entity, a verification mail is sent, because the users mail also gets unverified in the process (it's a new address after all; but we should ask Product and UX if this is actually preferred)