### PR TITLE
feat(http): allow trusted proxies to be defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.21.0 - 24 August 2023
+- Allow for trusted proxies to be configured
+
 ## 8x.20.0 - 23 August 2023
 - Add public /wiki endpoint
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -15,6 +15,7 @@ class Kernel extends HttpKernel
      */
     protected $middleware = [
         \Fruitcake\Cors\HandleCors::class,
+        \Illuminate\Http\Middleware\TrustProxies::class,
     ];
 
     /**

--- a/config/app.php
+++ b/config/app.php
@@ -252,5 +252,4 @@ return [
         'View' => Illuminate\Support\Facades\View::class,
 
     ],
-
 ];

--- a/config/trustedproxy.php
+++ b/config/trustedproxy.php
@@ -1,0 +1,17 @@
+<?php
+
+return [
+    'proxies' => (function () {
+        $split = array_filter(
+            explode(',', env('TRUSTED_PROXY_PROXIES', ''))
+        );
+        switch (count($split)) {
+        case 0:
+            return null;
+        case 1:
+            return $split[0];
+        default:
+            return $split;
+        }
+    })(),
+];


### PR DESCRIPTION
After deploying #635 to staging I noticed links in pagination responses would be using the `http` protocol, when the application itself is served using `https`. This seems to be due to the fact that as configured, Laravel does not trust any proxies at all and will think the client is the ingress, which rewrites to `http`: https://github.com/wbstack/charts/blob/af3206a791b345a70dd8b1670e20ff3d4e30d57a/charts/api/templates/ingress.yaml#L26-L37

This PR introduces the possibility of configuring trusted proxies as documented here: https://laravel.com/docs/8.x/requests#configuring-trusted-proxies
