### PR TITLE
fix(jobs): allow failures when collecting platform stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.21.1 - 29 August 2023
+- Continue collecting platform stats when single job failed
+
 ## 8x.21.0 - 24 August 2023
 - Allow for trusted proxies to be configured
 

--- a/app/Console/Commands/ScheduleStatsUpdates.php
+++ b/app/Console/Commands/ScheduleStatsUpdates.php
@@ -51,10 +51,11 @@ class ScheduleStatsUpdates extends Command
 
         Log::info(__METHOD__ . ": Scheduling updates for " . count($siteStatsUpdateJobs) . " wikis.");
 
-        Bus::chain([
-            ...$siteStatsUpdateJobs,
-            new PlatformStatsSummaryJob()
-        ])->dispatch();
+        Bus::batch($siteStatsUpdateJobs)
+            ->allowFailures()
+            ->then(function () {
+                dispatch(new PlatformStatsSummaryJob());
+            })->dispatch();
         return 0;
     }
 }


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T345139

Currently, there's a wiki called `então.carolinadoran.com` that breaks platform stats as MediaWiki does not like the `ã` in a host header. Using `batch` instead of `chain` tolerates failed jobs and will just continue running the sibling jobs.