### PR TITLE
fix(jobs): Also run PlatformStatsSummaryJob if preceding jobs failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.21.2 - 29 August 2023
+- Also run PlatformStatsSummaryJob if preceding jobs failed
+
 ## 8x.21.1 - 29 August 2023
 - Continue collecting platform stats when single job failed
 

--- a/app/Console/Commands/ScheduleStatsUpdates.php
+++ b/app/Console/Commands/ScheduleStatsUpdates.php
@@ -53,7 +53,7 @@ class ScheduleStatsUpdates extends Command
 
         Bus::batch($siteStatsUpdateJobs)
             ->allowFailures()
-            ->then(function () {
+            ->finally(function () {
                 dispatch(new PlatformStatsSummaryJob());
             })->dispatch();
         return 0;


### PR DESCRIPTION
In https://github.com/wbstack/api/pull/639 I missed that `then` would only run if all jobs succeeded, when we want it to always run.