### PR TITLE
fix: create migration for batches table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # api
 
+## 8x.21.3 - 30 August 2023
+- Add migration for creating batches table
+- Make batched job batchable
+
 ## 8x.21.2 - 29 August 2023
 - Also run PlatformStatsSummaryJob if preceding jobs failed
 

--- a/app/Jobs/SiteStatsUpdateJob.php
+++ b/app/Jobs/SiteStatsUpdateJob.php
@@ -5,6 +5,8 @@ namespace App\Jobs;
 use App\Wiki;
 use Illuminate\Support\Facades\Log;
 use App\Http\Curl\HttpRequest;
+use Illuminate\Bus\Batchable;
+
 
 /*
 *
@@ -14,15 +16,17 @@ use App\Http\Curl\HttpRequest;
 */
 class SiteStatsUpdateJob extends Job
 {
+    use Batchable;
+
     private $wiki_id;
 
     public function __construct( $wiki_id ) {
         $this->wiki_id = $wiki_id;
     }
-    
+
     public function handle( HttpRequest $request ): void
     {
-        $timeStart = microtime(true); 
+        $timeStart = microtime(true);
 
         $wiki = Wiki::where('id', $this->wiki_id)->first();
         if( !$wiki ) {
@@ -44,7 +48,7 @@ class SiteStatsUpdateJob extends Job
             ],
         ]);
 
-        $rawResponse = $request->execute(); 
+        $rawResponse = $request->execute();
         $err = $request->error();
         $request->close();
 

--- a/database/migrations/2023_08_29_145247_create_job_batches_table.php
+++ b/database/migrations/2023_08_29_145247_create_job_batches_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateJobBatchesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('job_batches', function (Blueprint $table) {
+            $table->string('id')->primary();
+            $table->string('name');
+            $table->integer('total_jobs');
+            $table->integer('pending_jobs');
+            $table->integer('failed_jobs');
+            $table->text('failed_job_ids');
+            $table->mediumText('options')->nullable();
+            $table->integer('cancelled_at')->nullable();
+            $table->integer('created_at');
+            $table->integer('finished_at')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('job_batches');
+    }
+}


### PR DESCRIPTION
After deploying #640 to staging, running the `schedule:stats` command fails with
```
  SQLSTATE[42S02]: Base table or view not found: 1146 Table 'apidb.job_batches' doesn't exist  
```
as we now require a batches table to be created. The migration in this PR has been created automatically using

```
php artisan queue:batches-table
```