### PR TITLE
fix(api): use correct config key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 8x.22.1 - 13 September 2023
 - Prevent multiple job invocations from reusing the same K8s client instance
+- fix for using the correct recaptcha config key
 
 ## 8x.22.0 - 05 September 2023
 - Remove `albertcht/invisible-recaptcha` package

--- a/app/Providers/ReCaptchaServiceProvider.php
+++ b/app/Providers/ReCaptchaServiceProvider.php
@@ -17,7 +17,7 @@ class ReCaptchaServiceProvider extends ServiceProvider
     {        
         $this->app->bind(ReCaptchaValidation::class, function($app) {
             $recaptcha = new ReCaptcha(
-                config('recaptcha.secret')
+                config('recaptcha.secret_key')
             );
 
             return new ReCaptchaValidation(

--- a/tests/Validation/ReCaptchaValidationTest.php
+++ b/tests/Validation/ReCaptchaValidationTest.php
@@ -14,7 +14,7 @@ class ReCaptchaValidationTest extends TestCase
     {
         $mockRuleBuilder = $this->getMockBuilder(ReCaptcha::class);
         $mockRuleBuilder->setConstructorArgs([
-            config('recaptcha.secretKey', 'someSecret'),
+            config('recaptcha.secret_key', 'someSecret'),
         ]);
         $mockRuleBuilder->onlyMethods([
             'verify'


### PR DESCRIPTION
The previous release did not use the correct recaptcha secret config key.

