### PR TITLE
fix: injected k8s client should not be a singleton

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.22.1 - TBD
+- Prevent multiple job invocations from reusing the same K8s client instance
+
 ## 8x.22.0 - 05 September 2023
 - Remove `albertcht/invisible-recaptcha` package
 - Add validation class App\Rules\RecaptchaValidation for using `google/recaptcha` package

--- a/app/Providers/KubernetesClientServiceProvider.php
+++ b/app/Providers/KubernetesClientServiceProvider.php
@@ -15,7 +15,7 @@ class KubernetesClientServiceProvider extends ServiceProvider
      */
     public function register()
     {
-        $this->app->singleton(Client::class , function ($app) {
+        $this->app->bind(Client::class , function ($app) {
             $httpClient = Guzzle6Client::createWithConfig([
                 'verify' => '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
             ]);


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T345605

Having the client injected as a singleton means that users would need to "clean up" after their usage. As the client is stateful and remembers for example the targeted namespace, this can lead to conflicts between users in case the instance would be reused. Making this a new instance each time should be more predictable.