### PR TITLE
fix: load laravel helper in local env only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.22.2 - 13 September 2023
+- Prevent Laravel IDE helper from being loaded in staging
+
 ## 8x.22.1 - 13 September 2023
 - Prevent multiple job invocations from reusing the same K8s client instance
 - fix for using the correct recaptcha config key

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -18,7 +18,7 @@ class AppServiceProvider extends ServiceProvider
     public function register()
     {
         // https://github.com/barryvdh/laravel-ide-helper
-        if ($this->app->environment() !== 'production') {
+        if ($this->app->environment() === 'local') {
             $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
         }
 


### PR DESCRIPTION
This fixes a side effect of merging https://github.com/wmde/wbaas-deploy/pull/1141 where staging would now try to load the Laravel IDE helper and fail https://console.cloud.google.com/errors/detail/CJydmNP-pNSZ-AE;time=P30D?project=wikibase-cloud