### PR TITLE
Increase EventPageUpdate pruning rate

### DIFF
--- a/app/Jobs/PruneEventPageUpdatesTable.php
+++ b/app/Jobs/PruneEventPageUpdatesTable.php
@@ -10,10 +10,10 @@ class PruneEventPageUpdatesTable extends Job
     public function handle(): void
     {
         // Assume that we only need the latest 100k page update events
-        // and delete 100 if there are too many
+        // and delete 500 if there are too many
         EventPageUpdate::where('id', '<', DB::table('event_page_updates')->max('id') - 100000)
             ->orderBy('id', 'ASC')
-            ->take(100)
+            ->take(500)
             ->delete();
     }
 }


### PR DESCRIPTION
This commit multiplies by 5 the rate at which we prune events.

Given our long term average prune rate and remaining EventPageUpdates this should be fast enough to keep us pruning to the 100k level we're targeting