### PR TITLE
Increase QsBatch prune rate

### DIFF
--- a/app/Jobs/PruneQueryserviceBatchesTable.php
+++ b/app/Jobs/PruneQueryserviceBatchesTable.php
@@ -9,11 +9,10 @@ class PruneQueryserviceBatchesTable extends Job
 {
     public function handle(): void
     {
-        // TODO possibly have some sort of user output...
         QsBatch::where('done', 1)
             ->where('updated_at', '<', Carbon::now()->subMonths(1))
             ->orderBy('id', 'ASC')
-            ->take(50)
+            ->take(250)
             ->delete();
     }
 }


### PR DESCRIPTION
This commit increases the rate we prune batches older than 1 month by 5 times.

I hope but have not calculated that this is sufficient to keep us pruning at the rate we are generating Batches.