### PR TITLE
fix(batches): do not purge db connection as it can be reused by following jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.25.1 - 12 October 2023
+- Do not purge DB connections in Platform Summary Job
+
 ## 8x.25.0 - 21 September 2023
 - Collect timestamps for Wikis' Lifecycle
 

--- a/app/Jobs/PlatformStatsSummaryJob.php
+++ b/app/Jobs/PlatformStatsSummaryJob.php
@@ -131,9 +131,6 @@ class PlatformStatsSummaryJob extends Job
     {
         $wikis = Wiki::withTrashed()->with('wikidb')->get();
 
-        $manager->purge('mw');
-        $manager->purge('mysql');
-
         $conn = $manager->connection('mysql');
         $mwConn = $manager->connection('mw');
 
@@ -160,9 +157,6 @@ class PlatformStatsSummaryJob extends Job
 
         $creationStats = $this->getCreationStats();
         $summary = array_merge($summary, $creationStats);
-
-        $manager->purge('mw');
-        $manager->purge('mysql');
 
         // Output to be scraped from logs
         if( !App::runningUnitTests() ) {


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T346245

For reasons unclear to me the failing jobs call this method in Laravel 
```php
    protected function registerBatchServices()
    {
        $this->app->singleton(BatchRepository::class, DatabaseBatchRepository::class);

        $this->app->singleton(DatabaseBatchRepository::class, function ($app) {
            return new DatabaseBatchRepository(
                $app->make(BatchFactory::class),
                $app->make('db')->connection($app->config->get('queue.batching.database')),
                $app->config->get('queue.batching.table', 'job_batches')
            );
        });
    }
```

returning a `null` connection as the value is not configured. I still don't understand why some invocations don't call this method and succeed. I also don't understand why this isn't documented at all.