### PR TITLE
Release 8x.25.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # api
 
+## 8x.25.2 - 19 October 2023
+- Bump Various Github Actions packages
+  - Should be no-op for container images
+
 ## 8x.25.1 - 12 October 2023
 - Do not purge DB connections in Platform Summary Job
 


### PR DESCRIPTION
Small release to test if the new version of `create-pull-request` is functional in additional to batching the other GitHub actions changes we expect to be no-ops