### PR TITLE
fix(qs): response is expected to be double wrapped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.25.4 - 25 October 2023
+- Fix response shape in QueryService controller
+
 ## 8x.25.3 - 25 October 2023
 - Add support for non-ascii domains
 - Adjust QueryService updater batch order

--- a/app/Http/Controllers/Backend/QsController.php
+++ b/app/Http/Controllers/Backend/QsController.php
@@ -74,7 +74,7 @@ class QsController extends Controller
 
             $oldestBatch->update(['done' => 1]);
             $oldestBatch->load(['wiki', 'wiki.wikiQueryserviceNamespace']);
-            return response($oldestBatch);
+            return response([$oldestBatch]);
         });
 
     }

--- a/tests/Routes/QsBatch/QsControllerTest.php
+++ b/tests/Routes/QsBatch/QsControllerTest.php
@@ -44,8 +44,9 @@ class QsControllerTest extends TestCase
         QsBatch::factory()->create(['id' => 2, 'done' => 0, 'eventFrom' => 1, 'eventTo' => 2, 'wiki_id' => 99, 'entityIds' => 'a,b']);
         QsBatch::factory()->create(['id' => 3, 'done' => 0, 'eventFrom' => 1, 'eventTo' => 2, 'wiki_id' => 99, 'entityIds' => 'a,b']);
         $this->json('GET', $this->route.'/getBatches')
-            ->assertJsonFragment(['id' => 2, 'done' => 1])
-            ->assertJsonPath('wiki.domain', 'test.wikibase.cloud')
+            ->assertJsonPath('0.id', 2)
+            ->assertJsonPath('0.done', 1)
+            ->assertJsonPath('0.wiki.domain', 'test.wikibase.cloud')
             ->assertStatus(200);
     }
 
@@ -57,8 +58,9 @@ class QsControllerTest extends TestCase
         EventPageUpdate::factory()->create(['wiki_id' => 111, 'namespace' => 120, 'title' => 'name']);
 
         $this->json('GET', $this->route.'/getBatches')
-            ->assertJsonFragment(['id' => 1, 'done' => 1])
-            ->assertJsonPath('wiki.domain', 'test.wikibase.cloud')
+            ->assertJsonPath('0.id', 1)
+            ->assertJsonPath('0.done', 1)
+            ->assertJsonPath('0.wiki.domain', 'test.wikibase.cloud')
             ->assertStatus(200);
 
         $this->assertEquals(QsBatch::query()->count(), 3);


### PR DESCRIPTION
Fixup for #673 

Regression was introduced here https://github.com/wbstack/api/pull/673/files#diff-75c86b3ca73e3c47740d3c186ab6b9985f9aaecff21755727c2e56847d7da998L93