### PR TITLE
Add raw information to ConversionMetrics

### DIFF
--- a/app/Http/Controllers/ConversionMetricController.php
+++ b/app/Http/Controllers/ConversionMetricController.php
@@ -37,11 +37,11 @@ class ConversionMetricController extends Controller
             $time_before_wiki_abandoned_days = null;
             $time_to_engage_days = null;
 
-            if (!is_null($wikiLastEditedTime) && ($current_date->diffInDays($wikiLastEditedTime) >= 90)) {
-                $time_before_wiki_abandoned_days = $wikiLastEditedTime->diffInDays($wiki->created_at);
+            if (!is_null($wikiLastEditedTime) && ($wikiLastEditedTime->diffInDays($current_date, false) >= 90)) {
+                $time_before_wiki_abandoned_days = $wiki->created_at->diffInDays($wikiLastEditedTime, false);
             }
             if ($wikiFirstEditedTime !== null) {
-                $time_to_engage_days = $wikiFirstEditedTime->diffInDays($wiki->created_at);
+                $time_to_engage_days = $wiki->created_at->diffInDays($wikiFirstEditedTime, false);
             }
             $wiki_number_of_editors = $wiki->wikiSiteStats()->first()['activeusers'] ?? null;
 

--- a/app/Http/Controllers/ConversionMetricController.php
+++ b/app/Http/Controllers/ConversionMetricController.php
@@ -49,7 +49,10 @@ class ConversionMetricController extends Controller
                 'domain' => $wiki->domain,
                 'time_to_engage_days' => $time_to_engage_days,
                 'time_before_wiki_abandoned_days' => $time_before_wiki_abandoned_days,
-                'number_of_active_editors' => $wiki_number_of_editors
+                'number_of_active_editors' => $wiki_number_of_editors,
+                'wiki_creation_time' => $wiki->created_at,
+                'first_edited_time' => $wikiFirstEditedTime,
+                'last_edited_time' => $wikiLastEditedTime
             ];
 
         }
@@ -65,7 +68,7 @@ class ConversionMetricController extends Controller
     private function returnCsv( $output ) {
         ob_start();
 		$handle = fopen('php://output', 'r+');
-        fputcsv($handle, ['domain_name', 'time_to_engage_days', 'time_before_wiki_abandoned_days', 'number_of_active_editors']);
+        fputcsv($handle, ['domain_name', 'time_to_engage_days', 'time_before_wiki_abandoned_days', 'number_of_active_editors', 'wiki_creation_time', 'first_edited_time', 'last_edited_time']);
         foreach ($output as $wikiMetrics) {
             fputcsv($handle, array_values($wikiMetrics));
         }

--- a/tests/Routes/Wiki/ConversionMetricTest.php
+++ b/tests/Routes/Wiki/ConversionMetricTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Tests\Routes\Wiki;
+use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Tests\Routes\Traits\OptionsRequestAllowed;
 use Tests\TestCase;
@@ -21,6 +22,8 @@ class ConversionMetricTest extends TestCase
         Wiki::query()->delete();
         WikiSiteStats::query()->delete();
         WikiSetting::query()->delete();
+        Carbon::setTestNow(Carbon::parse('first day of October 2023'));
+        CarbonImmutable::setTestNow(Carbon::parse('first day of October 2023'));
     }
 
     public function tearDown(): void {
@@ -78,7 +81,9 @@ class ConversionMetricTest extends TestCase
                 'domain' => 'new.but.never.edited.wikibase.cloud',
                 'time_to_engage_days' => null,
                 'time_before_wiki_abandoned_days' => null,
-                'number_of_active_editors' => 0
+                'number_of_active_editors' => 0,
+                'first_edited_time' => null,
+                'last_edited_time' => null
             ]
         );
         $response->assertJsonFragment(
@@ -94,7 +99,10 @@ class ConversionMetricTest extends TestCase
                 'domain' => 'old.and.used.only.one.week.wikibase.cloud',
                 'time_to_engage_days' => 7,
                 'time_before_wiki_abandoned_days' => 14,
-                'number_of_active_editors' => 0
+                'number_of_active_editors' => 0,
+                'wiki_creation_time' => CarbonImmutable::now()->subWeeks(53),
+                'first_edited_time' => CarbonImmutable::now()->subWeeks(52),
+                'last_edited_time' => CarbonImmutable::now()->subWeeks(51),
             ]
         );
         $response->assertJsonFragment(

--- a/tests/Routes/Wiki/ConversionMetricTest.php
+++ b/tests/Routes/Wiki/ConversionMetricTest.php
@@ -30,6 +30,8 @@ class ConversionMetricTest extends TestCase
         Wiki::query()->delete();
         WikiSiteStats::query()->delete();
         WikiSetting::query()->delete();
+        Carbon::setTestNow();
+        CarbonImmutable::setTestNow();
         parent::tearDown();
     }
 

--- a/tests/Routes/Wiki/ConversionMetricTest.php
+++ b/tests/Routes/Wiki/ConversionMetricTest.php
@@ -70,6 +70,7 @@ class ConversionMetricTest extends TestCase
         $this->createTestWiki('old.and.used.only.one.week.wikibase.cloud', 53, 52, 51 );
         $this->createTestWiki('unused.for.a.year.but.now.active.wikibase.cloud', 53, 1, 0, 4 );
         $this->createTestWiki('acvtively.used.for.the.last.year.wikibase.cloud', 53, 53, 0, 5 );
+        $this->createTestWiki('creation.time.after.first.edit.wikibase.cloud', 0, 53, 0, 1 );
         $response = $this->getJson($this->route);
         $response->assertStatus(200);
         $response->assertJsonFragment(
@@ -110,6 +111,14 @@ class ConversionMetricTest extends TestCase
                 'time_to_engage_days' => 0,
                 'time_before_wiki_abandoned_days' => null,
                 'number_of_active_editors' => 5
+            ]
+        );
+        $response->assertJsonFragment(
+            [
+                'domain' => 'creation.time.after.first.edit.wikibase.cloud',
+                'time_to_engage_days' => -371,
+                'time_before_wiki_abandoned_days' => null,
+                'number_of_active_editors' => 1
             ]
         );
     }


### PR DESCRIPTION
Adds raw creation, first and last edit times to ConversionMetrics.

Also uses non-absolute values for engagement and abandonment time
this accounts for edge cases where we import wikis such that they have edits
before they are created on this WBStack instance