### PR TITLE
fix(db): title column for event_page_update data is too short

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.25.7 - 8 November 2023
+- Title column for event_page_update data is now a `text` field
+
 ## 8x.25.6 - 25 October 2023
 - Add additional raw info to Conversion Metrics
 

--- a/database/migrations/2023_11_06_084718_event_page_update_title_length.php
+++ b/database/migrations/2023_11_06_084718_event_page_update_title_length.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\EventPageUpdate;
+
+class EventPageUpdateTitleLength extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('event_page_updates', function (Blueprint $table) {
+            $table->text('title')->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        EventPageUpdate::query()->get()->each(function (EventPageUpdate $eventPageUpdate) {
+            $eventPageUpdate->update(['title' => substr($eventPageUpdate->title, 0, 14)]);
+        });
+        Schema::table('event_page_updates', function (Blueprint $table) {
+            $table->string('title', 14)->change();
+        });
+    }
+}


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T350401

For reviewing, the easiest way to reproduce the error is create a wiki page with a title like `ThisStringIsALotLongerThanFourteenCharactersWillItBeInsertedStill`?