### PR TITLE
fix(jobs): empty wiki notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.27.1 - 20 November 2023
+- Hotfix for functionality added in 8x.27.0 (#686)
+
 ## 8x.27.0 - 14 November 2023
 - Add daily execution of empty wiki notifications (T344689)
 

--- a/app/Jobs/SendEmptyWikiNotificationsJob.php
+++ b/app/Jobs/SendEmptyWikiNotificationsJob.php
@@ -37,6 +37,8 @@ class SendEmptyWikiNotificationsJob extends Job implements ShouldBeUnique
         $now = CarbonImmutable::now();
         $emptyWikiDays = $createdAt->diffInDays($now);
 
+        dd($wiki->wikiLifecycleEvents);
+
         $firstEdited = $wiki->wikiLifecycleEvents->first_edited;
 
         $emptyWikiNotificationCount = WikiNotificationSentRecord::where([

--- a/app/Jobs/SendEmptyWikiNotificationsJob.php
+++ b/app/Jobs/SendEmptyWikiNotificationsJob.php
@@ -37,8 +37,6 @@ class SendEmptyWikiNotificationsJob extends Job implements ShouldBeUnique
         $now = CarbonImmutable::now();
         $emptyWikiDays = $createdAt->diffInDays($now);
 
-        dd($wiki->wikiLifecycleEvents);
-
         $firstEdited = $wiki->wikiLifecycleEvents->first_edited;
 
         $emptyWikiNotificationCount = WikiNotificationSentRecord::where([

--- a/app/Jobs/SendEmptyWikiNotificationsJob.php
+++ b/app/Jobs/SendEmptyWikiNotificationsJob.php
@@ -13,7 +13,9 @@ class SendEmptyWikiNotificationsJob extends Job implements ShouldBeUnique
 {
     public function handle (): void
     {
-        $wikis = Wiki::with(['wikiLifecycleEvents'])->get();
+        $wikis = Wiki::with(['wikiLifecycleEvents'])
+            ->has('wikiLifecycleEvents')
+            ->get();
 
         foreach ($wikis as $wiki) {
             try {

--- a/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
+++ b/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
@@ -23,9 +23,11 @@ class SendEmptyWikiNotificationsJobTest extends TestCase
         // Other tests leave dangling wikis around so we need to clean them up
         parent::setUp();
         Wiki::query()->delete();
+        WikiLifecycleEvents::query()->delete();
     }
 
     public function tearDown(): void {
+        WikiLifecycleEvents::query()->delete();
         Wiki::query()->delete();
         parent::tearDown();
     }

--- a/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
+++ b/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
@@ -19,6 +19,17 @@ class SendEmptyWikiNotificationsJobTest extends TestCase
 {
     use RefreshDatabase;
 
+    public function setUp(): void {
+        // Other tests leave dangling wikis around so we need to clean them up
+        parent::setUp();
+        Wiki::query()->delete();
+    }
+
+    public function tearDown(): void {
+        Wiki::query()->delete();
+        parent::tearDown();
+    }
+
     // the job does not fail in general
     public function testEmptyWikiNotifications_Success()
     {

--- a/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
+++ b/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
@@ -53,6 +53,23 @@ class SendEmptyWikiNotificationsJobTest extends TestCase
         );
     }
 
+
+    // fresh wiki that does not have lifecycle event records yet
+    public function testEmptyWikiNotifications_FreshWiki()
+    {
+        $now = Carbon::now()->toDateTimeString();
+
+        Notification::fake();
+        $user = User::factory()->create(['verified' => true]);
+        $wiki = Wiki::factory()->create(['created_at' => $now]);
+        $manager = WikiManager::factory()->create(['wiki_id' => $wiki->id, 'user_id' => $user->id]);
+
+        $job = new SendEmptyWikiNotificationsJob();
+        $job->handle();
+
+        Notification::assertNothingSent();
+    }
+
     // non-empty wikis which are older than 30 days do not trigger notifications
     public function testEmptyWikiNotifications_ActiveWiki()
     {

--- a/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
+++ b/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
@@ -19,19 +19,6 @@ class SendEmptyWikiNotificationsJobTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function setUp(): void {
-        // Other tests leave dangling wikis around so we need to clean them up
-        parent::setUp();
-        Wiki::query()->delete();
-        WikiLifecycleEvents::query()->delete();
-    }
-
-    public function tearDown(): void {
-        WikiLifecycleEvents::query()->delete();
-        Wiki::query()->delete();
-        parent::tearDown();
-    }
-
     // the job does not fail in general
     public function testEmptyWikiNotifications_Success()
     {
@@ -66,7 +53,6 @@ class SendEmptyWikiNotificationsJobTest extends TestCase
         );
     }
 
-
     // fresh wiki that does not have lifecycle event records yet
     public function testEmptyWikiNotifications_FreshWiki()
     {
@@ -78,6 +64,13 @@ class SendEmptyWikiNotificationsJobTest extends TestCase
         $manager = WikiManager::factory()->create(['wiki_id' => $wiki->id, 'user_id' => $user->id]);
 
         $job = new SendEmptyWikiNotificationsJob();
+
+        $mockJob = $this->createMock(Job::class);
+        $mockJob->expects($this->never())
+                ->method('fail')
+                ->withAnyParameters();
+
+        $job->setJob($mockJob);
         $job->handle();
 
         Notification::assertNothingSent();


### PR DESCRIPTION
https://phabricator.wikimedia.org/T344689#9340437

The job fails on wikis that got no `wikiLifecycleEvents` records. Such wikis won't get queried in the first place with this code.