### PR TITLE
fix(logging): add logging env vars to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Example: make test FILTER=tests/Jobs/ElasticSearchIndexInitTest.php
 test:
-	docker compose exec api bash -c 'LOG_CHANNEL=stderr vendor/bin/phpunit ${FILTER}'
+	docker compose exec api bash -c 'LOG_CHANNEL=stderr LOG_LEVEL=debug vendor/bin/phpunit ${FILTER}'
 
 init:
 	docker compose exec api bash -c 'php artisan migrate:fresh && php artisan passport:install && php artisan key:generate'

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 
 # Example: make test FILTER=tests/Jobs/ElasticSearchIndexInitTest.php
 test:
-	docker compose exec api vendor/bin/phpunit ${FILTER}
+	docker compose exec api bash -c 'LOG_CHANNEL=stderr vendor/bin/phpunit ${FILTER}'
 
 init:
 	docker compose exec api bash -c 'php artisan migrate:fresh && php artisan passport:install && php artisan key:generate'

--- a/config/logging.php
+++ b/config/logging.php
@@ -36,7 +36,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['daily'],
+            'channels' => ['daily', 'stderr'],
             'ignore_exceptions' => false,
         ],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -36,7 +36,7 @@ return [
     'channels' => [
         'stack' => [
             'driver' => 'stack',
-            'channels' => ['daily', 'stderr'],
+            'channels' => ['daily'],
             'ignore_exceptions' => false,
         ],
 


### PR DESCRIPTION
This adds the right log channel and level to the Makefile for enabling error output during running tests (deliberately not changed in `phpunit.xml` to still hide this output/noise in CI)