### PR TITLE
fix(qs): deduplicate entity ids before creating batches, skip deleted wikis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.28.1 - 27 November 2023
+- Do not create QsBatches for deleted wikis, deduplicate IDs (T348256)
+
 ## 8x.28.0 - 27 November 2023
 - Limit QsBatch sizes, run batch creation in dedicated job (T348256)
 

--- a/app/Jobs/CreateQueryserviceBatchesJob.php
+++ b/app/Jobs/CreateQueryserviceBatchesJob.php
@@ -30,9 +30,6 @@ class CreateQueryserviceBatchesJob extends Job
 
             [$newEntities, $latestEventId] = $this->getNewEntities($latestCheckpoint);
             foreach ($newEntities as $wikiId => $entityIdsFromEvents) {
-                if (!Wiki::where(['id' => $wikiId])->exists()) {
-                    continue;
-                }
                 try {
                     $success = $this->tryToAppendEntitesToExistingBatches($entityIdsFromEvents, $wikiId);
                     if ($success) {
@@ -57,6 +54,7 @@ class CreateQueryserviceBatchesJob extends Job
             'id', '>', $latestCheckpoint,
         )
             ->whereIn('namespace', [self::NAMESPACE_ITEM, self::NAMESPACE_PROPERTY, self::NAMESPACE_LEXEME])
+            ->has('wiki')
             ->get();
 
         $newEntitiesFromEvents = $events->reduce(function (array $result, EventPageUpdate $event) {

--- a/app/Jobs/CreateQueryserviceBatchesJob.php
+++ b/app/Jobs/CreateQueryserviceBatchesJob.php
@@ -94,7 +94,9 @@ class CreateQueryserviceBatchesJob extends Job
 
     private function createNewBatches(array $entityIdsFromEvents, int $wikiId): void
     {
-        $chunks = array_chunk($entityIdsFromEvents, $this->entityLimit);
+        $chunks = array_chunk(
+            array_unique($entityIdsFromEvents), $this->entityLimit,
+        );
         foreach ($chunks as $chunk) {
             QsBatch::create([
                 'done' => 0,

--- a/app/Jobs/CreateQueryserviceBatchesJob.php
+++ b/app/Jobs/CreateQueryserviceBatchesJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\EventPageUpdate;
 use App\QsBatch;
+use App\Wiki;
 use App\QsCheckpoint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
@@ -29,6 +30,9 @@ class CreateQueryserviceBatchesJob extends Job
 
             [$newEntities, $latestEventId] = $this->getNewEntities($latestCheckpoint);
             foreach ($newEntities as $wikiId => $entityIdsFromEvents) {
+                if (!Wiki::where(['id' => $wikiId])->exists()) {
+                    continue;
+                }
                 try {
                     $success = $this->tryToAppendEntitesToExistingBatches($entityIdsFromEvents, $wikiId);
                     if ($success) {

--- a/app/Jobs/RequeuePendingQsBatchesJob.php
+++ b/app/Jobs/RequeuePendingQsBatchesJob.php
@@ -31,7 +31,10 @@ class RequeuePendingQsBatchesJob extends Job
 
             $threshold = Carbon::now()->subtract(new \DateInterval($this->pendingTimeout));
             QsBatch::where([['pending_since', '<>', null], ['pending_since', '<', $threshold]])
-                ->update(['pending_since' => null, 'done' => 0]);
+                ->increment(
+                    'processing_attempts', 1,
+                    ['pending_since' => null, 'done' => 0]
+                );
         });
     }
 }

--- a/tests/Jobs/CreateQueryserviceBatchesJobTest.php
+++ b/tests/Jobs/CreateQueryserviceBatchesJobTest.php
@@ -61,6 +61,8 @@ class CreateQueryserviceBatchesTest extends TestCase
         EventPageUpdate::factory()->create(['id' => 1, 'wiki_id' => 111, 'namespace' => 120, 'title' => 'Q21']);
         EventPageUpdate::factory()->create(['id' => 3, 'wiki_id' => 111, 'namespace' => 120, 'title' => 'Q12']);
         EventPageUpdate::factory()->create(['id' => 4, 'wiki_id' => 111, 'namespace' => 999, 'title' => 'Q999']);
+        // This is a duplicate and should therefore only show up once
+        EventPageUpdate::factory()->create(['id' => 5, 'wiki_id' => 111, 'namespace' => 120, 'title' => 'Q12']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();

--- a/tests/Jobs/CreateQueryserviceBatchesJobTest.php
+++ b/tests/Jobs/CreateQueryserviceBatchesJobTest.php
@@ -52,6 +52,7 @@ class CreateQueryserviceBatchesTest extends TestCase
 
     public function testBatchCreation (): void
     {
+        Wiki::factory()->create(['id' => 1, 'domain' => 'deleted.wikibase.cloud'])->delete();
         Wiki::factory()->create(['id' => 88, 'domain' => 'test1.wikibase.cloud']);
         Wiki::factory()->create(['id' => 99, 'domain' => 'test2.wikibase.cloud']);
         Wiki::factory()->create(['id' => 111, 'domain' => 'test3.wikibase.cloud']);
@@ -63,6 +64,8 @@ class CreateQueryserviceBatchesTest extends TestCase
         EventPageUpdate::factory()->create(['id' => 4, 'wiki_id' => 111, 'namespace' => 999, 'title' => 'Q999']);
         // This is a duplicate and should therefore only show up once
         EventPageUpdate::factory()->create(['id' => 5, 'wiki_id' => 111, 'namespace' => 120, 'title' => 'Q12']);
+        // This is a deleted wiki and should create a batch
+        EventPageUpdate::factory()->create(['id' => 6, 'wiki_id' => 1, 'namespace' => 120, 'title' => 'Q152']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();
@@ -75,6 +78,9 @@ class CreateQueryserviceBatchesTest extends TestCase
         $this->assertNotNull($newBatch);
         $this->assertEquals($newBatch->entityIds, 'Q12');
         $this->assertEquals(QsBatch::query()->count(), 3);
+
+        $batchForDeletedWiki = QsBatch::where(['wiki_id' => 1])->first();
+        $this->assertNull($batchForDeletedWiki);
     }
 
     public function testBatchMerging(): void

--- a/tests/Jobs/RequeuePendingQsBatchesJobTest.php
+++ b/tests/Jobs/RequeuePendingQsBatchesJobTest.php
@@ -39,5 +39,6 @@ class RequeuePendingQsBatchesJobTest extends TestCase
 
         $this->assertEquals(QsBatch::where('pending_since', '=', null)->count(), 2);
         $this->assertEquals(QsBatch::where('failed', '=', true)->count(), 1);
+        $this->assertEquals(QsBatch::where('id', '=', 2)->first()->processing_attempts, 1);
     }
 }


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T348256

Three fixups for #685 

1. Deduplicate entity ids before creating new batches
2. Do not create batches for wikis that have been deleted (the updater is unable to process these)
3. Increment processing attempts when requeuing a batch so unhandled exceptions in the updater are considered a failed attempt