### PR TITLE
fix(qs): hard increase memory_limit for qs batches job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.28.5 - 28 November 2023
+- Hard increase memory_limit for QsBatches job
+
 ## 8x.28.4 - 28 November 2023
 - Increase timeout for QsBatches job
 

--- a/app/Jobs/CreateQueryserviceBatchesJob.php
+++ b/app/Jobs/CreateQueryserviceBatchesJob.php
@@ -22,6 +22,8 @@ class CreateQueryserviceBatchesJob extends Job
 
     public function __construct()
     {
+        // TODO: find a better way to do this
+        ini_set('memory_limit', '512M');
         $this->entityLimit = Config::get('wbstack.qs_batch_entity_limit');
     }
 


### PR DESCRIPTION
The job is stil crashing

```
[2023-11-28 07:27:33] production.ERROR: Allowed memory size of 134217728 bytes exhausted (tried to allocate 8388616 bytes) {"exception":"[object] (Symfony\\Component\\ErrorHandler\\Error\\FatalError(code: 0): Allowed memory size of 134217728 bytes exhausted (tried to allocate 8388616 bytes) at /var/www/html/vendor/laravel/framework/src/Illuminate/Database/Connection.php:375)
```
This is probably the wrong solution, but maybe it helps in unblocking production