### PR TITLE
chore(jobs): stub handle method for qs batches job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.28.7 - 28 November 2023
+- Stub QsBatches job so queued job will proceed
+
 ## 8x.28.6 - 28 November 2023
 - Disable QsBatches job as it fails queue
 

--- a/app/Jobs/CreateQueryserviceBatchesJob.php
+++ b/app/Jobs/CreateQueryserviceBatchesJob.php
@@ -27,6 +27,8 @@ class CreateQueryserviceBatchesJob extends Job
 
     public function handle(): void
     {
+        return;
+        /**
         DB::transaction(function () {
             $latestCheckpoint = QsCheckpoint::get();
 
@@ -48,6 +50,7 @@ class CreateQueryserviceBatchesJob extends Job
 
             QsCheckpoint::set($latestEventId);
         });
+         */
     }
 
     private function getNewEntities(int $latestCheckpoint): array

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,6 +8,7 @@
   <testsuites>
     <testsuite name="Application Test Suite">
       <directory suffix="Test.php">./tests</directory>
+      <exclude>./tests/Jobs/CreateQueryserviceBatchesJobTest.php</exclude>
     </testsuite>
   </testsuites>
   <php>


### PR DESCRIPTION
Even after disabling, there's a backlog of jobs in the queue that make the queue pod fail