### PR TITLE
fix: run query for page updates in chunks to reduce memory pressure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # api
 
+
+## 8x.28.8 - 28 November 2023
+- Chunk query for all page update events in QsBatches job
+- Reenable QsBatches job
+
 ## 8x.28.7 - 28 November 2023
 - Stub QsBatches job so queued job will proceed
 

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -37,7 +37,7 @@ class Kernel extends ConsoleKernel
         $schedule->job(new ExpireOldUserVerificationTokensJob)->hourly();
         $schedule->job(new PruneEventPageUpdatesTable)->everyFifteenMinutes();
         $schedule->job(new PruneQueryserviceBatchesTable)->everyFifteenMinutes();
-        // $schedule->job(new CreateQueryserviceBatchesJob)->everyMinute();
+        $schedule->job(new CreateQueryserviceBatchesJob)->everyMinute();
         $schedule->job(new RequeuePendingQsBatchesJob)->everyFifteenMinutes();
 
         // Sandbox

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -8,7 +8,6 @@
   <testsuites>
     <testsuite name="Application Test Suite">
       <directory suffix="Test.php">./tests</directory>
-      <exclude>./tests/Jobs/CreateQueryserviceBatchesJobTest.php</exclude>
     </testsuite>
   </testsuites>
   <php>


### PR DESCRIPTION
According to benchmarks on the internet, `chunk` should be the least memory hungry option https://janostlund.com/2021-12-26/eloquent-cursor-vs-chunk