### PR TITLE
Ensure that report helper is called when a batch is failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # api
 
 
+## 8x.28.9 - 28 November 2023
+- Fix error reporting on detecting failed Qs Batches
+
 ## 8x.28.8 - 28 November 2023
 - Chunk query for all page update events in QsBatches job
 - Reenable QsBatches job

--- a/tests/Jobs/RequeuePendingQsBatchesJobTest.php
+++ b/tests/Jobs/RequeuePendingQsBatchesJobTest.php
@@ -8,6 +8,7 @@ use Tests\TestCase;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Contracts\Queue\Job;
 use Carbon\Carbon;
+use Illuminate\Contracts\Debug\ExceptionHandler;
 
 class RequeuePendingQsBatchesJobTest extends TestCase
 {
@@ -30,11 +31,17 @@ class RequeuePendingQsBatchesJobTest extends TestCase
         QsBatch::factory()->create(['pending_since' => Carbon::now()->subSeconds(400), 'id' => 2, 'done' => 0, 'wiki_id' => 1, 'entityIds' => 'a,b']);
         QsBatch::factory()->create(['processing_attempts' => 3, 'id' => 3, 'done' => 0, 'wiki_id' => 1, 'entityIds' => 'a,b']);
 
+        $mockExceptionHandler = $this->createMock(ExceptionHandler::class);
+        $mockExceptionHandler
+            ->expects($this->once())
+            ->method('report');
+        $this->app->instance(ExceptionHandler::class, $mockExceptionHandler);
+
         $mockJob = $this->createMock(Job::class);
         $job = new RequeuePendingQsBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
-            ->method('fail');
+          ->method('fail');
         $job->handle();
 
         $this->assertEquals(QsBatch::where('pending_since', '=', null)->count(), 2);

--- a/tests/Jobs/RequeuePendingQsBatchesJobTest.php
+++ b/tests/Jobs/RequeuePendingQsBatchesJobTest.php
@@ -41,7 +41,7 @@ class RequeuePendingQsBatchesJobTest extends TestCase
         $job = new RequeuePendingQsBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
-          ->method('fail');
+            ->method('fail');
         $job->handle();
 
         $this->assertEquals(QsBatch::where('pending_since', '=', null)->count(), 2);


### PR DESCRIPTION
When deploying #685 I noticed failed batches would not be reported.

It seems `tap` does not work as I thought it would be and instead of giving us the updated models down the chain, it would re-evaluate the query, yielding 0 results on `->get()` as the update just happened and nothing matches the query anymore.

Instead, we can query for candidate ids, update these in a second query and then report.