### PR TITLE
Requeueing should not select failed batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # api
 
+## 8x.28.10 - 29 November 2023
+- Requeueing should not select failed batches
 
 ## 8x.28.9 - 28 November 2023
 - Fix error reporting on detecting failed Qs Batches

--- a/app/Jobs/RequeuePendingQsBatchesJob.php
+++ b/app/Jobs/RequeuePendingQsBatchesJob.php
@@ -37,7 +37,10 @@ class RequeuePendingQsBatchesJob extends Job
                 ->get()
                 ->pluck('id')
                 ->toArray();
-            QsBatch::whereIn('id', $failedBatches)->update(['failed' => true]);
+            QsBatch::whereIn('id', $failedBatches)->update([
+                'failed' => true,
+                'pending_since' => null,
+            ]);
             return $failedBatches;
         });
     }
@@ -48,10 +51,11 @@ class RequeuePendingQsBatchesJob extends Job
         QsBatch::where([
             ['pending_since', '<>', null],
             ['pending_since', '<', $threshold],
+            ['failed', '=', false],
         ])
             ->increment(
                 'processing_attempts', 1,
-                ['pending_since' => null, 'done' => 0]
+                ['pending_since' => null, 'done' => false]
             );
     }
 }

--- a/tests/Jobs/RequeuePendingQsBatchesJobTest.php
+++ b/tests/Jobs/RequeuePendingQsBatchesJobTest.php
@@ -30,6 +30,7 @@ class RequeuePendingQsBatchesJobTest extends TestCase
         QsBatch::factory()->create(['pending_since' => Carbon::now()->subSeconds(200), 'id' => 1, 'done' => 0, 'wiki_id' => 1, 'entityIds' => 'a,b']);
         QsBatch::factory()->create(['pending_since' => Carbon::now()->subSeconds(400), 'id' => 2, 'done' => 0, 'wiki_id' => 1, 'entityIds' => 'a,b']);
         QsBatch::factory()->create(['processing_attempts' => 3, 'id' => 3, 'done' => 0, 'wiki_id' => 1, 'entityIds' => 'a,b']);
+        QsBatch::factory()->create(['failed' => 1, 'processing_attempts' => 4, 'id' => 4, 'done' => 0, 'wiki_id' => 1, 'entityIds' => 'a,b']);
 
         $mockExceptionHandler = $this->createMock(ExceptionHandler::class);
         $mockExceptionHandler
@@ -44,8 +45,10 @@ class RequeuePendingQsBatchesJobTest extends TestCase
             ->method('fail');
         $job->handle();
 
-        $this->assertEquals(QsBatch::where('pending_since', '=', null)->count(), 2);
-        $this->assertEquals(QsBatch::where('failed', '=', true)->count(), 1);
+        $this->assertEquals(QsBatch::where('pending_since', '=', null)->count(), 3);
+        $this->assertEquals(QsBatch::where('failed', '=', true)->count(), 2);
         $this->assertEquals(QsBatch::where('id', '=', 2)->first()->processing_attempts, 1);
+        $this->assertEquals(QsBatch::where('id', '=', 4)->first()->processing_attempts, 4);
+        $this->assertEquals(QsBatch::where('id', '=', 4)->first()->pending_since, null);
     }
 }


### PR DESCRIPTION
Currently, failed jobs will still be selected by the query for requeuing, creating an incorrect number of processing attempts.

This has no user facing effect, but can be confusing when debugging.