### PR TITLE
feat(k8s): add job that can spawn one off queryservice-updater

### DIFF
--- a/app/Jobs/ProcessMediaWikiJobsJob.php
+++ b/app/Jobs/ProcessMediaWikiJobsJob.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Config;
 use Maclof\Kubernetes\Client;
 use Maclof\Kubernetes\Models\Job as KubernetesJob;
 
@@ -20,7 +21,7 @@ class ProcessMediaWikiJobsJob implements ShouldQueue, ShouldBeUnique
     public function __construct (string $wikiDomain)
     {
         $this->wikiDomain = $wikiDomain;
-        $this->jobsKubernetesNamespace = env('API_JOB_NAMESPACE', 'api-jobs');
+        $this->jobsKubernetesNamespace = Config::get('wbstack.api_job_namespace');
     }
 
     public function uniqueId(): string

--- a/app/Jobs/SpawnQueryserviceUpdaterJob.php
+++ b/app/Jobs/SpawnQueryserviceUpdaterJob.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Contracts\Queue\ShouldBeUnique;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Facades\Log;
+use Maclof\Kubernetes\Client;
+use Maclof\Kubernetes\Models\Job as KubernetesJob;
+
+class SpawnQueryserviceUpdaterJob implements ShouldQueue, ShouldBeUnique
+{
+    use InteractsWithQueue, Queueable;
+
+    private string $wikiDomain;
+    private string $entities;
+    private string $sparqlUrl;
+    private string $qsKubernetesNamespace;
+
+    public function __construct (string $wikiDomain, string $entites, string $sparqlUrl)
+    {
+        $this->wikiDomain = $wikiDomain;
+        $this->entities = $entites;
+        $this->sparqlUrl = $sparqlUrl;
+        $this->qsKubernetesNamespace = env('QS_JOB_NAMESPACE', 'qs-jobs');
+    }
+
+    public function uniqueId(): string
+    {
+        return $this->wikiDomain;
+    }
+
+    public function handle (Client $kubernetesClient): void
+    {
+        $kubernetesClient->setNamespace('default');
+        $qsUpdaterPod = $kubernetesClient->pods()->setFieldSelector([
+            'status.phase' => 'Running'
+        ])->setLabelSelector([
+            'app.kubernetes.io/name' => 'queryservice-updater',
+        ])->first();
+
+        if ($qsUpdaterPod === null) {
+            $this->fail(
+                new \RuntimeException(
+                    'Unable to find a running queryservice-updater pod in the cluster, '.
+                    'cannot continue.'
+                )
+            );
+            return;
+        }
+        $qsUpdaterPod = $qsUpdaterPod->toArray();
+
+        $kubernetesClient->setNamespace($this->qsKubernetesNamespace);
+        $jobSpec = new KubernetesJob([
+            'metadata' => [
+                'name' => 'run-qs-updater-'.hash('sha1', $this->wikiDomain),
+                'namespace' => $this->qsKubernetesNamespace,
+                'labels' => [
+                    'app.kubernetes.io/instance' => $this->wikiDomain,
+                    'app.kubernetes.io/name' => 'run-qs-updater'
+                ]
+            ],
+            'spec' => [
+                'ttlSecondsAfterFinished' => 14 * 24 * 60 * 60, // 2 weeks
+                'template' => [
+                    'metadata' => [
+                        'name' => 'run-qs-updater'
+                    ],
+                    'spec' => [
+                        'containers' => [
+                            0 => [
+                                'name' => 'run-qs-updater',
+                                'image' => $qsUpdaterPod['spec']['containers'][0]['image'],
+                                'env' => $qsUpdaterPod['spec']['containers'][0]['env'],
+                                'command' => [
+                                    0 => 'bash',
+                                    1 => '-c',
+                                    2 => <<<CMD
+                                    /wdqsup/runUpdateWbStack.sh -- \
+                                        --wikibaseHost {$this->wikiDomain} \
+                                        --ids {$this->entities} \
+                                        --entityNamespaces 120,122,146 \
+                                        --sparqlUrl {$this->sparqlUrl} \
+                                        --wikibaseScheme http \
+                                        --conceptUri https://{$this->wikiDomain}
+                                    CMD
+                                ],
+                            ]
+                        ],
+                        'restartPolicy' => 'Never'
+                    ]
+                ]
+            ]
+        ]);
+
+        $job = $kubernetesClient->jobs()->apply($jobSpec);
+        $jobName = data_get($job, 'metadata.name');
+        if (!$jobName) {
+            // The k8s client does not fail reliably on 4xx responses, so checking the name
+            // currently serves as poor man's error handling.
+            $this->fail(
+                new \RuntimeException('Queryservice Updater creation for wiki "'.$this->wikiDomain.'" failed.')
+            );
+            return;
+        }
+        Log::info(
+            'Querysevice Updater for wiki "'.$this->wikiDomain.'" exists or was created with name "'.$jobName.'".'
+        );
+
+        return;
+    }
+
+}

--- a/app/Jobs/SpawnQueryserviceUpdaterJob.php
+++ b/app/Jobs/SpawnQueryserviceUpdaterJob.php
@@ -7,6 +7,7 @@ use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Contracts\Queue\ShouldBeUnique;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Config;
 use Maclof\Kubernetes\Client;
 use Maclof\Kubernetes\Models\Job as KubernetesJob;
 
@@ -23,10 +24,11 @@ class SpawnQueryserviceUpdaterJob implements ShouldQueue, ShouldBeUnique
     {
         $sortedEntities = explode(',', $entities);
         asort($sortedEntities);
+
         $this->wikiDomain = $wikiDomain;
         $this->entities = implode(',', $sortedEntities);
         $this->sparqlUrl = $sparqlUrl;
-        $this->qsKubernetesNamespace = env('QS_JOB_NAMESPACE', 'qs-jobs');
+        $this->qsKubernetesNamespace = Config::get('wbstack.qs_job_namespace');
     }
 
     public function uniqueId(): string

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -28,4 +28,7 @@ return [
     'qs_batch_pending_timeout' => env('WBSTACK_QS_BATCH_PENDING_TIMEOUT', 'PT300S'),
     'qs_batch_mark_failed_after' => intval(env('WBSTACK_QS_BATCH_MARK_FAILED_AFTER', '3')),
     'qs_batch_entity_limit' => intval(env('WBSTACK_QS_BATCH_ENTITY_LIMIT', '10')),
+
+    'api_job_namespace' => env('API_JOB_NAMESPACE') || env('WBSTACK_API_JOB_NAMESPACE', 'api-jobs'),
+    'qs_job_namespace' => env('WBSTACK_QS_JOB_NAMESPACE', 'qs-jobs'),
 ];

--- a/tests/Jobs/SpawnQueryserviceUpdaterJobTest.php
+++ b/tests/Jobs/SpawnQueryserviceUpdaterJobTest.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace Tests\Jobs;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+use Illuminate\Contracts\Queue\Job;
+use App\Jobs\SpawnQueryserviceUpdaterJob;
+use Maclof\Kubernetes\Client;
+use Http\Adapter\Guzzle6\Client as Guzzle6Client;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\Psr7\Response;
+
+class SpawnQueryserviceUpdaterJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testJobFailOnNoUpdaterPod()
+    {
+        $mockJob = $this->createMock(Job::class);
+        $mockJob->expects($this->once())->method('fail');
+
+        $job = new SpawnQueryserviceUpdaterJob(
+            'test.wikibase.cloud',
+            'Q1,P1,Q2,P2,Q3',
+            'http://wdqs.svc:9999/bigdata/namespace/wdq/sparql',
+        );
+        $job->setJob($mockJob);
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([ 'items' => [] ])),
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $mockGuzzle = Guzzle6Client::createWithConfig([
+            'handler' => $handlerStack,
+            'verify' => '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+        ]);
+
+        $job->handle(new Client([
+            'master' => 'https://kubernetes.default.svc',
+            'token' => '/var/run/secrets/kubernetes.io/serviceaccount/token',
+        ], null, $mockGuzzle));
+    }
+
+    public function testJobDoesNotFail()
+    {
+        $mockJob = $this->createMock(Job::class);
+        $mockJob->expects($this->never())->method('fail');
+
+        $job = new SpawnQueryserviceUpdaterJob(
+            'test.wikibase.cloud',
+            'Q1,P1,Q2,P2,Q3',
+            'http://wdqs.svc:9999/bigdata/namespace/wdq/sparql',
+        );
+        $job->setJob($mockJob);
+
+        $mock = new MockHandler([
+            new Response(200, [], json_encode([ 'items' => [
+                [
+                    'kind' => 'Pod',
+                    'spec' => [
+                        'containers' => [
+                            [
+                                'image' => 'helloworld',
+                                'env' => [
+                                    'SOMETHING' => 'something'
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]])),
+            new Response(200, [], json_encode([ 'items' => [] ])),
+            new Response(201, [], json_encode([
+                'metadata' => [
+                    'name' => 'some-job-name'
+                ]
+            ]))
+        ]);
+
+        $handlerStack = HandlerStack::create($mock);
+        $mockGuzzle = Guzzle6Client::createWithConfig([
+            'handler' => $handlerStack,
+            'verify' => '/var/run/secrets/kubernetes.io/serviceaccount/ca.crt',
+        ]);
+
+        $job->handle(new Client([
+            'master' => 'https://kubernetes.default.svc',
+            'token' => '/var/run/secrets/kubernetes.io/serviceaccount/token',
+        ], null, $mockGuzzle));
+    }
+}


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T352657

Connects https://github.com/wbstack/queryservice-updater/pull/143

Note that this PR does only provide the Job class but does not yet create such jobs. This shall happen in a dedicated PR (#704) which introduces a command for creating jobs for all entities in all wikis.