### PR TITLE
Add QuestyCaptcha WikiSettings to API

### DIFF
--- a/app/Http/Controllers/WikiSettingController.php
+++ b/app/Http/Controllers/WikiSettingController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Rules\SettingCaptchaQuestions;
 use App\Rules\SettingWikibaseManifestEquivEntities;
 use App\WikiManager;
 use App\WikiSetting;
@@ -26,6 +27,8 @@ class WikiSettingController extends Controller
             'wwWikibaseStringLengthMultilang' => ['required', 'integer', 'between:250,2500'],
             'wikibaseFedPropsEnable' => ['required', 'boolean'],
             'wikibaseManifestEquivEntities' => ['required', 'json', new SettingWikibaseManifestEquivEntities()],
+            'wwUseQuestyCaptcha' => ['required', 'boolean'],
+            'wwCaptchaQuestions' => [ 'required', 'json', new SettingCaptchaQuestions()]
         ];
     }
 

--- a/app/Rules/SettingCaptchaQuestions.php
+++ b/app/Rules/SettingCaptchaQuestions.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Rules;
+
+use Illuminate\Contracts\Validation\Rule;
+
+class SettingCaptchaQuestions implements Rule
+{
+    /**
+     * Determine if the validation rule passes.
+     *
+     * @param  string  $attribute
+     * @param  mixed  $value
+     * @return bool
+     */
+    public function passes($attribute, $value)
+    {
+        $value = json_decode($value, true);
+
+        if ($value === null) {
+            return false;
+        }
+
+        foreach (array_keys($value) as $question) {
+            if (!is_string($question)) {
+                return false;
+            }
+            if (strlen($question) > 200) {
+                return false;
+            }
+        }
+
+        foreach (array_values($value) as $answers) {
+            if (!is_array($answers)) {
+                return false;
+            }
+            if (count($answers) === 0) {
+                return false;
+            }
+            foreach ($answers as $answer) {
+                if (!is_string($answer)) {
+                    return false;
+                }
+                if (strlen($answer) > 200) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Get the validation error message.
+     */
+    public function message(): string
+    {
+        return 'Value must be JSON mapping of questions to an array of answers and neither question nor answers may be longer than 200 chars';
+    }
+}

--- a/tests/Routes/Wiki/SettingUpdateTest.php
+++ b/tests/Routes/Wiki/SettingUpdateTest.php
@@ -71,6 +71,15 @@ class SettingUpdateTest extends TestCase
 
         $validProps = json_encode(['properties' => ['P31' => 'P1'], 'items' => ['Q1' => 'Q1']]);
         yield ['wikibaseManifestEquivEntities', $validProps, $validProps];
+
+        yield ['wwUseQuestyCaptcha', '1', '1'];
+        yield ['wwUseQuestyCaptcha', '0', '0'];
+        $validCaptchaQuestions = json_encode([
+            "How many vowels are in this question?" => ['12', 'twelve'],
+            "What is the chemical formula of water" => ['H2O'],
+            "2 + 4 = ?" => ['6', 'six']
+        ]);
+        yield ['wwCaptchaQuestions', $validCaptchaQuestions, $validCaptchaQuestions ];
     }
 
     /**
@@ -118,6 +127,26 @@ class SettingUpdateTest extends TestCase
         yield ['wikibaseManifestEquivEntities', json_encode(['properties' => ['P1' => 'P2'], 'items' => ['P10' => 'Q2']])];
         // all entities should be of the same type
         yield ['wikibaseManifestEquivEntities', json_encode(['properties' => ['P1' => 'P2'], 'items' => ['Q2' => 'Q2', 'P2' => 'P2']])];
+        // no answers
+        yield ['wwCaptchaQuestions', json_encode([
+            "How many vowels are in this question?" => []
+        ])];
+        // Question too long
+        yield ['wwCaptchaQuestions', json_encode([
+            "How many vowels are in this question?How many vowels are in this question?
+            How many vowels are in this question?How many vowels are in this question?
+            How many vowels are in this question?How many vowels are in this question?
+            How many vowels are in this question?How many vowels are in this question?" => ['12', 'twelve']
+        ])];
+        // Answer too long
+        yield ['wwCaptchaQuestions', json_encode([
+            "Is this too long?" => [
+                "LongAnswerLongAnswerLongAnswerLongAnswerLongAnswerLongAnswerLongAnswer
+                LongAnswerLongAnswerLongAnswerLongAnswerLongAnswerLongAnswerLongAnswer
+                LongAnswerLongAnswerLongAnswerLongAnswerLongAnswerLongAnswerLongAnswer
+                LongAnswerLongAnswerLongAnswerLongAnswerLongAnswerLongAnswerLongAnswer"
+            ]
+        ])];
     }
 
     /**


### PR DESCRIPTION
Adds two new types of WikiSetting to the platform api to manage using QuestyCaptcha.

It adds a boolean setting for turning the feature on and off as well as a totally independent setting for the questions.
This enables wiki administrators to store and curate their questions even when the setting is disabled.

It does not provide any default questions; this has been done in the UI.

This follows the existing pattern for equivalent entities and therefore stores the settings map as JSON. This can be mildly confusing since there in then double encoded JSON in the payloads to and from this API.

Validation for the content of the questions is also minimal; there is no escaping of html content in the questions since, as I understand it, this is handled in MW[1].

This can be merged independently of wbstack/mediawiki#405 but if you care to test them then it may be easier to do in parallel.

[1] https://doc.wikimedia.org/mediawiki-core/1.27.1/php/classHtml.html#a1c74fee14762ec4d50e09a94c94327ef