### PR TITLE
fix: edit items in place when stripping prefixes, do not use regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 # api
 
-## 8x.28.11 - 12 December 2023
-- Batches that are done shall never be marked failed
+## 8x.29.1 - 13 December 2023
+- Try to fix memory exhaustion issue when running wbs-qs:rebuild command
 
 ## 8x.29.0 - 13 December 2023
 - Add command for rebuilding Queryservice data
+
+## 8x.28.11 - 12 December 2023
+- Batches that are done shall never be marked failed
 
 ## 8x.28.10 - 29 November 2023
 - Requeueing should not select failed batches

--- a/app/Console/Commands/RebuildQueryserviceData.php
+++ b/app/Console/Commands/RebuildQueryserviceData.php
@@ -92,7 +92,8 @@ class RebuildQueryserviceData extends Command
             : [];
 
         $merged = array_merge($items, $properties, $lexemes);
-        return $this->stripPrefixes($merged);
+        $this->stripPrefixes($merged);
+        return $merged;
     }
 
     private function getSparqlUrl (Wiki $wiki): string
@@ -154,10 +155,11 @@ class RebuildQueryserviceData extends Command
         return $titles;
     }
 
-    private static function stripPrefixes (array $items): array
+    private static function stripPrefixes (array &$items): void
     {
-        return array_map(function (string $item) {
-            return preg_replace('/^[a-zA-Z]+:/', '', $item);
-        }, $items);
+        foreach ($items as &$item) {
+            $e = explode(':', $item);
+            $item = end($e);
+        }
     }
 }


### PR DESCRIPTION
Running the command in staging made the command exit 

```
In RebuildQueryserviceData.php line 159:
                                                                                       
  Allowed memory size of 134217728 bytes exhausted (tried to allocate 33554440 bytes)  
                                                                                       
```

I'm not entirely sure what exactly consumes so much memory, but this PR tries to mitigate this by doing two things:
- edit the array of IDs in place
- use `split` instead of `preg_replace`