### PR TITLE
fix(mw-jobs): fix env var lookup, print error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 8x.31.1 - 18 December 2023
+- Fix namespace lookup for api-jobs
+
 ## 8x.31.0 - 14 December 2023
 - Dispatch jobs for rebuilding Queryservice data to non-default queue
 

--- a/app/Jobs/ProcessMediaWikiJobsJob.php
+++ b/app/Jobs/ProcessMediaWikiJobsJob.php
@@ -101,11 +101,11 @@ class ProcessMediaWikiJobsJob implements ShouldQueue, ShouldBeUnique
 
         $job = $kubernetesClient->jobs()->apply($jobSpec);
         $jobName = data_get($job, 'metadata.name');
-        if (!$jobName) {
+        if (data_get($job, 'status') === 'Failure' || !$jobName) {
             // The k8s client does not fail reliably on 4xx responses, so checking the name
             // currently serves as poor man's error handling.
             $this->fail(
-                new \RuntimeException('Job creation for wiki "'.$this->wikiDomain.'" failed.')
+                new \RuntimeException('Job creation for wiki "'.$this->wikiDomain.'" failed with message: '.data_get($job, 'message', 'n/a'))
             );
             return;
         }

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -29,6 +29,6 @@ return [
     'qs_batch_mark_failed_after' => intval(env('WBSTACK_QS_BATCH_MARK_FAILED_AFTER', '3')),
     'qs_batch_entity_limit' => intval(env('WBSTACK_QS_BATCH_ENTITY_LIMIT', '10')),
 
-    'api_job_namespace' => env('API_JOB_NAMESPACE') || env('WBSTACK_API_JOB_NAMESPACE', 'api-jobs'),
+    'api_job_namespace' => env('API_JOB_NAMESPACE', env('WBSTACK_API_JOB_NAMESPACE', 'api-jobs')),
     'qs_job_namespace' => env('WBSTACK_QS_JOB_NAMESPACE', 'qs-jobs'),
 ];


### PR DESCRIPTION
Fixes a bug introduced [here](https://github.com/wbstack/api/pull/701/files#r1414981809), where the namespace for `api-jobs` would now yield `true` instead of the env var:

```
>>> Config::get('wbstack.api_job_namespace')
=> true
```