### PR TITLE
fix(static-assets): raw assets are being passed bad options arg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 9x.0.1 - 23 January 2024
+- Fix typo when setting visibility on raw assets
+
 ## 9x.0.0 - 23 January 2024
 - Update Laravel to version 9
 

--- a/app/Jobs/SetWikiLogo.php
+++ b/app/Jobs/SetWikiLogo.php
@@ -66,7 +66,7 @@ class SetWikiLogo extends Job
         $logosDir = Wiki::getLogosDirectory($wiki->id);
 
         // Upload the local image to the cloud storage
-        $storage->putFileAs($logosDir, new File($this->logoPath), "raw.png", ['visibilty' => 'public']);
+        $storage->putFileAs($logosDir, new File($this->logoPath), "raw.png", ['visibility' => 'public']);
 
         // Store a conversion for the actual site logo
         $reducedPath = $logosDir . '/135.png';


### PR DESCRIPTION
Fixup for #727 

We didn't notice this as the raw image is currently never loaded in wikis.