### PR TITLE
fix(qs-batches): retry running transactions that require db locks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 9x.0.2 - 07 February 2024
+- Retry DB transactions that lock
+
 ## 9x.0.1 - 23 January 2024
 - Fix typo when setting visibility on raw assets
 

--- a/app/Http/Controllers/Backend/QsController.php
+++ b/app/Http/Controllers/Backend/QsController.php
@@ -29,7 +29,7 @@ class QsController extends Controller
             $oldestBatch->update(['pending_since' => Carbon::now()]);
             $oldestBatch->load(['wiki', 'wiki.wikiQueryserviceNamespace']);
             return response([$oldestBatch]);
-        });
+        }, 3);
 
     }
 

--- a/app/Jobs/CreateQueryserviceBatchesJob.php
+++ b/app/Jobs/CreateQueryserviceBatchesJob.php
@@ -47,7 +47,7 @@ class CreateQueryserviceBatchesJob extends Job
             }
 
             QsCheckpoint::set($latestEventId);
-        });
+        }, 3);
     }
 
     private function getNewEntities(int $latestCheckpoint): array

--- a/app/Jobs/RequeuePendingQsBatchesJob.php
+++ b/app/Jobs/RequeuePendingQsBatchesJob.php
@@ -44,7 +44,7 @@ class RequeuePendingQsBatchesJob extends Job
                 'pending_since' => null,
             ]);
             return $failedBatches;
-        });
+        }, 3);
     }
 
     private function requeueStalledBatches(): void


### PR DESCRIPTION
This is a fixup for #721 

Apparently transactions that cannot acquire a lock now fail (which is expected), so we should retry them afterwards a couple of times before giving up. Laravel's `DB::transaction` can do this for us.