### PR TITLE
Release 9x.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 9x.0.3 - 08 February 2024
+- Updates a number of github action dependencies
+
 ## 9x.0.2 - 07 February 2024
 - Retry DB transactions that lock
 


### PR DESCRIPTION
Updates a number of github action dependencies.

Highly unlikely to be an issue but by releasing and deploying a version we'll not have these changes confused with other work.