### PR TITLE
suggestion: add intentionally failing Job

### DIFF
--- a/app/Jobs/FailJob.php
+++ b/app/Jobs/FailJob.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Jobs;
+
+class FailJob extends Job
+{
+	public function handle(): void
+	{
+		$this->fail(self::class.': The job failed successfully (this is intended, as this is a test Job). Have a nice day.');
+	}
+}
+


### PR DESCRIPTION
Just a suggestion, happy to not include this and open for other ideas to fulfill the purpose.

Context: I wanted to test error reporting and was unclear how to trigger an error without much work, like taking mediawiki deployments down or something. This makes triggering an error cheap (although we probably won't need it much, but the maintenance cost of this seems very low to me).

Infamously used by me in the past, see: https://mattermost.wikimedia.de/swe/pl/ftmz3i6bs781zqm7fdzzuk3phr

