### PR TITLE
readme: Add links to Phabricator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> ℹ️ Issues for this repository are tracked on [Phabricator](https://phabricator.wikimedia.org/project/board/5563/) - ([Click here to open a new one](https://phabricator.wikimedia.org/maniphest/task/edit/form/1/?tags=wikibase_cloud,wbstack_api
+))
+> 
 # WBStack Platform API
 ## Configuration
 The platform API comes in a few different flavours that can be toggled using environment variables:


### PR DESCRIPTION
The Issues feature on this repo is now disabled as I moved all the open issues to Phabricator