### PR TITLE
fix(horizon): add stub configs for all environments that are deployed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 10x.1.1 - 14 March 2024
+- Declare Horizon configuration stubs for all known environments
+
 ## 10x.1.0 - 14 March 2024
 - Use Laravel Horizon to supervise queue workers if enabled T342866
 

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -194,4 +194,9 @@ return [
             'timeout' => intval(env('HORIZON_TIMEOUT', 60)),
         ],
     ],
+    'environments' => [
+        'local' => ['supervisor-1' => []],
+        'staging' => ['supervisor-1' => []],
+        'production' => ['supervisor-1' => []],
+    ],
 ];


### PR DESCRIPTION
It seems the default configuration only declares supervisors for `local` and `production` envs (https://github.com/laravel/horizon/blob/0f6a1dd80f7ec3f448a46578c07f0a872ebb07a9/config/horizon.php#L198-L212), which made #753 not do anything when deployed to staging.

This PR fixes this by declaring stubs for all environments known to wikibase.cloud.