### PR TITLE
Ask for feedback before deleting a WB instance to ask "why"

### DIFF
--- a/app/Http/Controllers/DeletedWikiMetricsController.php
+++ b/app/Http/Controllers/DeletedWikiMetricsController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Wiki;
+use App\WikiManager;
+use Carbon\CarbonImmutable;
+use Illuminate\Http\Request;
+
+class DeletedWikiMetricsController extends Controller
+{
+
+    private string $fileName="deleted_wiki_metric.csv";
+
+    /**
+     * Produce a downloadable csv file with deleted wiki metrics.
+     */
+    public function index(Request $request)
+    {
+        $allDeletedWikis = Wiki::OnlyTrashed()->get();
+        $output = [];
+
+        foreach ($allDeletedWikis as $wiki) {
+            $userId = WikiManager::whereWikiId($wiki->id)->first()['user_id'];
+
+            $output[] = [
+                'domain' => $wiki->domain,
+                'wiki_deletion_reason' => $wiki->wiki_deletion_reason,
+                'number_of_wikibases_for_user' => WikiManager::whereUserId($userId)->count(),
+                'number_of_wiki_edits_for_wiki'=> $wiki->wikiSiteStats()->first()['edits'],
+                'number_of_entities_for_wiki' => "No value available for now",
+                'number_of_wiki_pages_for_wiki' => $wiki->wikiSiteStats()->first()['pages'],
+                'number_of_users_for_wiki' => $wiki->wikiSiteStats()->first()['users'],
+                'wiki_creation_time' => $wiki->created_at,
+                'wiki_deletion_time' => $wiki->deleted_at,
+            ];
+        }
+
+        if ( $request->wantsJson() ) {
+            return response()->json( $output );
+        }
+
+        return $this->returnCsv($output);
+
+    }
+
+    private function returnCsv( $output ) {
+        ob_start();
+        $handle = fopen('php://output', 'r+');
+        fputcsv($handle, [
+            'domain_name_for_wiki',
+            'wiki_deletion_reason',
+            'number_of_wikibases_for_user',
+            'number_of_wiki_edits_for_wiki',
+            'number_of_entities_for_wiki',
+            'number_of_wiki_pages_for_wiki',
+            'number_of_users_for_wiki',
+            'wiki_creation_time',
+            'wiki_deletion_time',
+            ]);
+        foreach ($output as $deletedWikiMetrics) {
+            fputcsv($handle, array_values($deletedWikiMetrics));
+        }
+        $csv = ob_get_clean();
+        return response($csv, 200, [
+            'Content-Type' => 'text/csv',
+            'Content-Disposition' => 'attachment;filename='.CarbonImmutable::now()->toIso8601String().'-'.$this->fileName
+        ]);
+    }
+}

--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -174,15 +174,16 @@ class WikiController extends Controller
             // The deletion was requested by a user that does not manage the wiki
             return response()->json('Unauthorized', 401);
         }
+        $wiki = Wiki::find($wikiId);
 
         //Save the wiki deletion reason
-        Wiki::find($wikiId)->update(['wiki_deletion_reason' => $wikiDeletionReason]);
+        $wiki->update(['wiki_deletion_reason' => $wikiDeletionReason]);
 
         // Delete the wiki
-        Wiki::find($wikiId)->delete();
+        $wiki->delete();
 
         // Return a success
-        return response()->json('Success', 200);
+        return response()->json($wiki->wiki_deletion_reason, 200);
     }
 
     // TODO should this just be get wiki?

--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -44,7 +44,7 @@ class WikiController extends Controller
         }
 
         $user = $request->user();
-        
+
         $submittedDomain = strtolower($request->input('domain'));
         $submittedDomain = DomainHelper::encode($submittedDomain);
 
@@ -141,7 +141,7 @@ class WikiController extends Controller
                 dispatch(new ElasticSearchAliasInit($wiki->id));
             }
         }
-        
+
         // opportunistic dispatching of jobs to make sure storage pools are topped up
         dispatch(new ProvisionWikiDbJob(null, null, 10));
         dispatch(new ProvisionQueryserviceNamespaceJob(null, 10));
@@ -167,12 +167,16 @@ class WikiController extends Controller
 
         $wikiId = $request->input('wiki');
         $userId = $user->id;
+        $wikiDeletionReason = $request->input('deletionReason');
 
         // Check that the requesting user manages the wiki
         if (WikiManager::where('user_id', $userId)->where('wiki_id', $wikiId)->count() !== 1) {
             // The deletion was requested by a user that does not manage the wiki
             return response()->json('Unauthorized', 401);
         }
+
+        //Save the wiki deletion reason
+        Wiki::find($wikiId)->update(['wiki_deletion_reason' => $wikiDeletionReason]);
 
         // Delete the wiki
         Wiki::find($wikiId)->delete();

--- a/app/Http/Middleware/AuthorisedUsersForDeletedWikiMetricsMiddleware.php
+++ b/app/Http/Middleware/AuthorisedUsersForDeletedWikiMetricsMiddleware.php
@@ -16,9 +16,10 @@ class AuthorisedUsersForDeletedWikiMetricsMiddleware
     public function handle(Request $request, Closure $next): Response
     {
         $user = $request->user();
-        if(!$user->is_admin) {
-            return redirect()->route('wiki');
+        if(!is_null($user) && $user->is_admin) {
+            return $next($request);
         }
         return $next($request);
+        //return redirect()->route('login');
     }
 }

--- a/app/Http/Middleware/AuthorisedUsersForDeletedWikiMetricsMiddleware.php
+++ b/app/Http/Middleware/AuthorisedUsersForDeletedWikiMetricsMiddleware.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class AuthorisedUsersForDeletedWikiMetricsMiddleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+        if(!$user->is_admin) {
+            return redirect()->route('wiki');
+        }
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/AuthorisedUsersForDeletedWikiMetricsMiddleware.php
+++ b/app/Http/Middleware/AuthorisedUsersForDeletedWikiMetricsMiddleware.php
@@ -16,10 +16,9 @@ class AuthorisedUsersForDeletedWikiMetricsMiddleware
     public function handle(Request $request, Closure $next): Response
     {
         $user = $request->user();
-        if(!is_null($user) && $user->is_admin) {
+        if(!is_null($user) && $user->is_admin === 1) {
             return $next($request);
         }
-        return $next($request);
-        //return redirect()->route('login');
+        return redirect()->route('login');
     }
 }

--- a/app/User.php
+++ b/app/User.php
@@ -74,6 +74,7 @@ class User extends Authenticatable implements MustVerifyEmail
         'trial_ends_at',
         'card_brand',
         'card_last_four',
+        'is_admin',
     ];
 
     /**

--- a/app/Wiki.php
+++ b/app/Wiki.php
@@ -52,6 +52,7 @@ class Wiki extends Model
         'domain',
         'description',
         'is_featured',
+        'wiki_deletion_reason',
     ];
 
     /**

--- a/database/migrations/2024_05_15_042959_add_admin_role_to_users.php
+++ b/database/migrations/2024_05_15_042959_add_admin_role_to_users.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/database/migrations/2024_05_15_042959_add_admin_role_to_users.php
+++ b/database/migrations/2024_05_15_042959_add_admin_role_to_users.php
@@ -11,8 +11,9 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // is_admin is 0 for plain users and an integer > 0 for admins
         Schema::table('users', function (Blueprint $table) {
-            $table->boolean('is_admin')->default(false);
+            $table->integer('is_admin')->default(false);
         });
     }
 

--- a/database/migrations/2024_05_15_043447_add_wiki_deletion_reason.php
+++ b/database/migrations/2024_05_15_043447_add_wiki_deletion_reason.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('wikis', function (Blueprint $table) {
+            $table->string('wiki_deletion_reason')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('wikis', function (Blueprint $table) {
+            $table->dropColumn('wiki_deletion_reason');
+        });
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Middleware\AuthorisedUsersForDeletedWikiMetricsMiddleware;
 use Illuminate\Support\Facades\Config;
 
 /**
@@ -20,6 +21,8 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router) {
 
     $router->apiResource('wiki', 'PublicWikiController')->only(['index', 'show']);
     $router->apiResource('wikiConversionData', 'ConversionMetricController')->only(['index']);
+    $router->apiResource('deletedWikiMetrics', 'DeletedWikiMetricsController')->only(['index'])
+        ->middleware(AuthorisedUsersForDeletedWikiMetricsMiddleware::class);
 
     $router->post('auth/login', ['uses' => 'Auth\LoginController@postLogin']);
     // Authed

--- a/routes/api.php
+++ b/routes/api.php
@@ -24,7 +24,7 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router) {
     $router->apiResource('deletedWikiMetrics', 'DeletedWikiMetricsController')->only(['index'])
         ->middleware(AuthorisedUsersForDeletedWikiMetricsMiddleware::class);
 
-    $router->post('auth/login', ['uses' => 'Auth\LoginController@postLogin']);
+    $router->post('auth/login', ['uses' => 'Auth\LoginController@postLogin'])->name('login');
     // Authed
     $router->group(['middleware' => ['auth:api']], function () use ($router) {
         $router->get('auth/login', ['uses' => 'Auth\LoginController@getLogin']);

--- a/tests/Jobs/DeleteWikiJobTest.php
+++ b/tests/Jobs/DeleteWikiJobTest.php
@@ -76,13 +76,13 @@ class DeleteWikiJobTest extends TestCase
 
         // Would be injected by the app
         $manager = $this->app->make('db');
-  
+
         $job = new ProvisionWikiDbJob($databases[0]['prefix'], $databases[0]['name'], null);
         $job->handle($manager);
 
         // Would be injected by the app
         $manager = $this->app->make('db');
-  
+
         $job = new ProvisionWikiDbJob($databases[1]['prefix'], $databases[1]['name'], null);
         $job->handle($manager);
 
@@ -165,7 +165,7 @@ class DeleteWikiJobTest extends TestCase
         $mockJob->expects($this->once())
                 ->method('fail')
                 ->with(new \RuntimeException(str_replace('<WIKI_ID>', $wiki_id, $expectedFailure)));
-                
+
         $job = new DeleteWikiDbJob($wiki_id);
         $job->setJob($mockJob);
         $job->handle($mockMananger);

--- a/tests/Routes/Wiki/DeleteWikiTest.php
+++ b/tests/Routes/Wiki/DeleteWikiTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Routes\Wiki\Managers;
+
+use App\User;
+use App\Wiki;
+use App\WikiManager;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Tests\TestCase;
+
+class DeleteWikiTest extends TestCase
+{
+    use HasFactory;
+
+    public function testDelete()
+    {
+
+        $user = User::factory()->create(['verified' => true]);
+        $wiki = Wiki::factory('nodb')->create();
+        WikiManager::factory()->create(['wiki_id' => $wiki->id, 'user_id' => $user->id]);
+
+        $response = $this
+            ->actingAs($user, 'api')
+            ->post(
+                'wiki/delete',
+                ['wiki' => $wiki->id, 'deletionReason' => 'Some reason for deleting my wiki']
+            );
+        // check response is correct
+        $response->assertStatus(200);
+        $this->assertSame('Some reason for deleting my wiki', $response->original);
+    }
+}

--- a/tests/Routes/Wiki/DeletedWikiMetricsControllerTest.php
+++ b/tests/Routes/Wiki/DeletedWikiMetricsControllerTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Routes\Wiki;
+use App\Http\Controllers\WikiController;
+use App\WikiManager;
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Tests\Routes\Traits\OptionsRequestAllowed;
+use Tests\TestCase;
+use App\WikiSiteStats;
+use App\WikiSetting;
+use App\Wiki;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+class DeletedWikiMetricsControllerTest extends TestCase
+{
+    protected string $route = 'deletedWikiMetrics';
+
+    use OptionsRequestAllowed;
+    use DatabaseTransactions;
+
+    public function setUp(): void {
+        parent::setUp();
+        Wiki::query()->delete();
+        WikiSiteStats::query()->delete();
+        WikiSetting::query()->delete();
+    }
+
+    public function tearDown(): void {
+        Wiki::query()->delete();
+        WikiSiteStats::query()->delete();
+        WikiSetting::query()->delete();
+        parent::tearDown();
+    }
+
+    public function testDownloadCsv()
+    {
+        $this->createAndDeleteTestWiki('one.wikibase.cloud', 0, '',1, 2);
+        $this->createAndDeleteTestWiki( 'two.wikibase.cloud', 0, 'Some Reason', 0, 3 );
+        $response = $this->get($this->route);
+        $response->assertStatus(200)
+            ->assertDownload(CarbonImmutable::now()->toIso8601String().'-deleted_wiki_metric.csv');
+    }
+
+    private function createAndDeleteTestWiki($name, $user_id, $wikiDeletionReason, $createdWeeksAgo = 1, $wiki_users = 1) {
+        $current_date = CarbonImmutable::now();
+
+        $wiki = Wiki::factory()->create([
+            'domain' => $name, 'sitename' => 'bsite'
+        ]);
+        WikiManager::factory()->create( [
+            'wiki_id' => $wiki->id, 'user_id' => $user_id,
+        ] );
+        WikiSiteStats::factory()->create([
+            'wiki_id' => $wiki->id, 'pages' => 77, 'users' => $wiki_users
+        ]);
+        $wiki->created_at = $current_date->subWeeks($createdWeeksAgo);
+
+        $wiki->save();
+        Wiki::find($wiki)->update(['wiki_deletion_reason' => $wikiDeletionReason]);
+        Wiki::find($wiki)->delete();
+    }
+
+    public function testDownloadJson() {
+        $this->createAndDeleteTestWiki('new.but.never.edited.wikibase.cloud', 0, 'new wiki no edits deleted');
+        $this->createAndDeleteTestWiki('old.and.never.edited.wikibase.cloud', 53, 'old wiki no edits deleted');
+        $this->createAndDeleteTestWiki('old.and.used.wikibase.cloud', 53, '', 52, 51);
+        $this->createAndDeleteTestWiki('no.deletion.reason.wikibase.cloud', 53, '', 2, 4);
+        $this->createAndDeleteTestWiki('acvtively.used.for.the.last.year.wikibase.cloud', 53, 'Some weird reason', 53, 5);
+        $this->createAndDeleteTestWiki('no.deletion.reason.two.wikibase.cloud', 0,'', 53);
+        $response = $this->getJson($this->route);
+        $response->assertStatus(200);
+        $response->assertJsonFragment(
+            [
+                'domain' => 'new.but.never.edited.wikibase.cloud',
+                'wiki_deletion_reason' => 'new wiki no edits deleted',
+                'number_of_users' => 1,
+            ]
+        );
+        $response->assertJsonFragment(
+            [
+                'domain' => 'old.and.never.edited.wikibase.cloud',
+                'wiki_deletion_reason' => 'old wiki no edits deleted',
+                'number_of_users' => 1,
+            ]
+        );
+        $response->assertJsonFragment(
+            [
+                'domain' => 'old.and.used.wikibase.cloud',
+                'wiki_deletion_reason' => '',
+                'number_of_users' => 51,
+            ]
+        );
+        $response->assertJsonFragment(
+            [
+                'domain' => 'no.deletion.reason.wikibase.cloud',
+                'wiki_deletion_reason' => '',
+                'number_of_users' => 4,
+            ]
+        );
+        $response->assertJsonFragment(
+            [
+                'domain' => 'acvtively.used.for.the.last.year.wikibase.cloud',
+                'wiki_deletion_reason' => 'Some weird reason',
+                'number_of_users' => 5,
+            ]
+        );
+        $response->assertJsonFragment(
+            [
+                'domain' => 'no.deletion.reason.two.wikibase.cloud',
+                'wiki_deletion_reason' => '',
+                'number_of_users' => 1,
+            ]
+        );
+    }
+}

--- a/tests/Routes/Wiki/DeletedWikiMetricsControllerTest.php
+++ b/tests/Routes/Wiki/DeletedWikiMetricsControllerTest.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Tests\Routes\Wiki;
+use App\Http\Controllers\DeletedWikiMetricsController;
 use App\User;
 use App\WikiManager;
 use Carbon\CarbonImmutable;
@@ -34,26 +35,68 @@ class DeletedWikiMetricsControllerTest extends TestCase
         parent::tearDown();
     }
 
-    public function testDownloadCsv()
+    public function testRedirectIfUserNotLoggedIn()
     {
         $this->createAndDeleteTestWiki('one.wikibase.cloud', 0, '', 1, 2);
-        $this->createAndDeleteTestWiki('two.wikibase.cloud', 0, 'Some Reason', 0, 3);
+        $this->createAndDeleteTestWiki('two.wikibase.cloud', 10, 'Some Reason', 0, 3);
+        $response = $this->get($this->route);
+        $response->assertStatus(302);
+    }
+    public function testRedirectIfUserIsLoggedInAsNotAdmin()
+    {
+        $user = $this->createUserWithPriviledges(0);
+        $this->actingAs($user, 'api')->get('auth/login');
+        $this->createAndDeleteTestWiki('one.wikibase.cloud', 0, '', 1, 2);
+        $this->createAndDeleteTestWiki('two.wikibase.cloud', 10, 'Some Reason', 0, 3);
+        $response = $this->get($this->route);
+        $response->assertStatus(302);
+    }
+
+    public function testDownloadCsvIfUserIsLoggedInAsAdmin()
+    {
+        $user = $this->createUserWithPriviledges(1);
+        $this->actingAs($user, 'api')->get('auth/login');
+        $this->createAndDeleteTestWiki('one.wikibase.cloud', 0, '', 1, 2);
+        $this->createAndDeleteTestWiki('two.wikibase.cloud', 10, 'Some Reason', 0, 3);
         $response = $this->get($this->route);
         $response->assertStatus(200)
             ->assertDownload(CarbonImmutable::now()->toIso8601String() . '-deleted_wiki_metric.csv');
     }
 
-    private function createUserAndSetPriviledges($userPriviledge)
+    public function testOutputHasCorrectContent()
     {
-        return User::factory()->create(['verified' => true, 'is_admin' => $userPriviledge]);
+        $user1 = User::factory()->create(['verified' => true,]);
+        $user2 = User::factory()->create(['verified' => true,]);
+        $deletedWikis = [
+            $this->createAndDeleteTestWiki('one.wikibase.cloud', $user1->id, '', 1, 2),
+            $this->createAndDeleteTestWiki('two.wikibase.cloud', $user2->id, 'Some Reason', 0, 3),
+        $this->createAndDeleteTestWiki('sameuser.wikibase.cloud', $user1->id, 'Some Reason', 0, 3),
+        ];
+        $controller = new DeletedWikiMetricsController();
+        $output = $controller->createOutput($deletedWikis);
+        $this->assertSame('one.wikibase.cloud', $output[0]['domain_name_for_wiki']);
+        $this->assertSame('two.wikibase.cloud', $output[1]['domain_name_for_wiki']);
+        $this->assertSame('Some Reason',$output[1]['wiki_deletion_reason']);
+        $this->assertSame(2, $output[0]['number_of_wikibases_owned_by_owners_of_this_wiki']);
     }
 
-    private function createAndDeleteTestWiki($name, $user_id, $wikiDeletionReason, $createdWeeksAgo = 1, $wiki_users = 1)
+    private function createUserWithPriviledges($userPriviledge)
+    {
+        $password = 'apassword';
+        return User::factory()->create([
+            'verified' => true,
+            'email' => 'atestmail@gmail.com',
+            'password' => password_hash($password, PASSWORD_DEFAULT),
+            'is_admin' => $userPriviledge
+        ]);
+    }
+
+    private function createAndDeleteTestWiki($domain, $user_id, $wikiDeletionReason, $createdWeeksAgo = 1, $wiki_users = 1)
     {
         $current_date = CarbonImmutable::now();
 
         $wiki = Wiki::factory()->create([
-            'domain' => $name, 'sitename' => 'bsite'
+            'domain' => $domain, 'sitename' => 'bsite'
         ]);
         WikiManager::factory()->create([
             'wiki_id' => $wiki->id, 'user_id' => $user_id,
@@ -64,7 +107,8 @@ class DeletedWikiMetricsControllerTest extends TestCase
         $wiki->created_at = $current_date->subWeeks($createdWeeksAgo);
 
         $wiki->save();
-        Wiki::find($wiki->id)->update(['wiki_deletion_reason' => $wikiDeletionReason]);
-        Wiki::find($wiki->id)->delete();
+        $wiki->update(['wiki_deletion_reason' => $wikiDeletionReason]);
+        $wiki->delete();
+        return $wiki;
     }
 }

--- a/tests/Routes/Wiki/DeletedWikiMetricsControllerTest.php
+++ b/tests/Routes/Wiki/DeletedWikiMetricsControllerTest.php
@@ -1,9 +1,8 @@
 <?php
 
 namespace Tests\Routes\Wiki;
-use App\Http\Controllers\WikiController;
+use App\User;
 use App\WikiManager;
-use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Tests\Routes\Traits\OptionsRequestAllowed;
 use Tests\TestCase;
@@ -19,14 +18,16 @@ class DeletedWikiMetricsControllerTest extends TestCase
     use OptionsRequestAllowed;
     use DatabaseTransactions;
 
-    public function setUp(): void {
+    public function setUp(): void
+    {
         parent::setUp();
         Wiki::query()->delete();
         WikiSiteStats::query()->delete();
         WikiSetting::query()->delete();
     }
 
-    public function tearDown(): void {
+    public function tearDown(): void
+    {
         Wiki::query()->delete();
         WikiSiteStats::query()->delete();
         WikiSetting::query()->delete();
@@ -35,82 +36,35 @@ class DeletedWikiMetricsControllerTest extends TestCase
 
     public function testDownloadCsv()
     {
-        $this->createAndDeleteTestWiki('one.wikibase.cloud', 0, '',1, 2);
-        $this->createAndDeleteTestWiki( 'two.wikibase.cloud', 0, 'Some Reason', 0, 3 );
+        $this->createAndDeleteTestWiki('one.wikibase.cloud', 0, '', 1, 2);
+        $this->createAndDeleteTestWiki('two.wikibase.cloud', 0, 'Some Reason', 0, 3);
         $response = $this->get($this->route);
         $response->assertStatus(200)
-            ->assertDownload(CarbonImmutable::now()->toIso8601String().'-deleted_wiki_metric.csv');
+            ->assertDownload(CarbonImmutable::now()->toIso8601String() . '-deleted_wiki_metric.csv');
     }
 
-    private function createAndDeleteTestWiki($name, $user_id, $wikiDeletionReason, $createdWeeksAgo = 1, $wiki_users = 1) {
+    private function createUserAndSetPriviledges($userPriviledge)
+    {
+        return User::factory()->create(['verified' => true, 'is_admin' => $userPriviledge]);
+    }
+
+    private function createAndDeleteTestWiki($name, $user_id, $wikiDeletionReason, $createdWeeksAgo = 1, $wiki_users = 1)
+    {
         $current_date = CarbonImmutable::now();
 
         $wiki = Wiki::factory()->create([
             'domain' => $name, 'sitename' => 'bsite'
         ]);
-        WikiManager::factory()->create( [
+        WikiManager::factory()->create([
             'wiki_id' => $wiki->id, 'user_id' => $user_id,
-        ] );
+        ]);
         WikiSiteStats::factory()->create([
             'wiki_id' => $wiki->id, 'pages' => 77, 'users' => $wiki_users
         ]);
         $wiki->created_at = $current_date->subWeeks($createdWeeksAgo);
 
         $wiki->save();
-        Wiki::find($wiki)->update(['wiki_deletion_reason' => $wikiDeletionReason]);
-        Wiki::find($wiki)->delete();
-    }
-
-    public function testDownloadJson() {
-        $this->createAndDeleteTestWiki('new.but.never.edited.wikibase.cloud', 0, 'new wiki no edits deleted');
-        $this->createAndDeleteTestWiki('old.and.never.edited.wikibase.cloud', 53, 'old wiki no edits deleted');
-        $this->createAndDeleteTestWiki('old.and.used.wikibase.cloud', 53, '', 52, 51);
-        $this->createAndDeleteTestWiki('no.deletion.reason.wikibase.cloud', 53, '', 2, 4);
-        $this->createAndDeleteTestWiki('acvtively.used.for.the.last.year.wikibase.cloud', 53, 'Some weird reason', 53, 5);
-        $this->createAndDeleteTestWiki('no.deletion.reason.two.wikibase.cloud', 0,'', 53);
-        $response = $this->getJson($this->route);
-        $response->assertStatus(200);
-        $response->assertJsonFragment(
-            [
-                'domain' => 'new.but.never.edited.wikibase.cloud',
-                'wiki_deletion_reason' => 'new wiki no edits deleted',
-                'number_of_users' => 1,
-            ]
-        );
-        $response->assertJsonFragment(
-            [
-                'domain' => 'old.and.never.edited.wikibase.cloud',
-                'wiki_deletion_reason' => 'old wiki no edits deleted',
-                'number_of_users' => 1,
-            ]
-        );
-        $response->assertJsonFragment(
-            [
-                'domain' => 'old.and.used.wikibase.cloud',
-                'wiki_deletion_reason' => '',
-                'number_of_users' => 51,
-            ]
-        );
-        $response->assertJsonFragment(
-            [
-                'domain' => 'no.deletion.reason.wikibase.cloud',
-                'wiki_deletion_reason' => '',
-                'number_of_users' => 4,
-            ]
-        );
-        $response->assertJsonFragment(
-            [
-                'domain' => 'acvtively.used.for.the.last.year.wikibase.cloud',
-                'wiki_deletion_reason' => 'Some weird reason',
-                'number_of_users' => 5,
-            ]
-        );
-        $response->assertJsonFragment(
-            [
-                'domain' => 'no.deletion.reason.two.wikibase.cloud',
-                'wiki_deletion_reason' => '',
-                'number_of_users' => 1,
-            ]
-        );
+        Wiki::find($wiki->id)->update(['wiki_deletion_reason' => $wikiDeletionReason]);
+        Wiki::find($wiki->id)->delete();
     }
 }


### PR DESCRIPTION
Responses are stored and can be accessed as a file and the download should only be visible to internal users