### PR TITLE
fix: platform stats summary job handling inactive wikis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 10x.5.0 - 8 May 2024
+- Fix PlatformSummaryStatsJob for inactive wikis
+
 ## 10x.4.0 - 6 May 2024
 - Allow cookie based authentication
 

--- a/app/Jobs/PlatformStatsSummaryJob.php
+++ b/app/Jobs/PlatformStatsSummaryJob.php
@@ -57,7 +57,7 @@ class PlatformStatsSummaryJob extends Job
 
         $deletedWikis = [];
         $activeWikis = [];
-        $inactive = [];
+        $inactiveWikis = [];
         $emptyWikis = [];
         $nonDeletedStats = [];
 
@@ -94,18 +94,19 @@ class PlatformStatsSummaryJob extends Job
 
             $nonDeletedStats[] = $stats;
 
-            // is it just inactive?
+            // is it active?
             if(!is_null($stats['lastEdit'])){
                 $lastTimestamp = intVal($stats['lastEdit']);
                 $diff = $currentTime - $lastTimestamp;
 
-                if ($diff >= $this->inactiveThreshold) {
-                    $inactive[] = $wiki;
+                if ($diff <= $this->inactiveThreshold) {
+                    $activeWikis[] = $wiki;
                     continue;
                 }
             }
 
-            $activeWikis[] = $wiki;
+            // if it's neither deleted, empty or active it must be inactive
+            $inactiveWikis[] = $wiki;
         }
 
         $totalNonDeletedUsers = array_sum(array_column($nonDeletedStats, 'users'));
@@ -118,7 +119,7 @@ class PlatformStatsSummaryJob extends Job
             'total' => count($wikis),
             'deleted' => count($deletedWikis),
             'active' => count($activeWikis),
-            'inactive' => count($inactive),
+            'inactive' => count($inactiveWikis),
             'empty' => count($emptyWikis),
             'total_non_deleted_users' => $totalNonDeletedUsers,
             'total_non_deleted_active_users' => $totalNonDeletedActiveUsers,

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -86,7 +86,8 @@ class PlatformStatsSummaryJobTest extends TestCase
             Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki1.com' ] ),
             Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki2.com' ] ),
             Wiki::factory()->create( [ 'deleted_at' => Carbon::now()->subDays(90)->timestamp, 'domain' => 'wiki3.com' ] ),
-            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki4.com' ] )
+            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki4.com' ] ),
+            Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki5.com' ] )
         ];
 
         foreach($wikis as $wiki) {
@@ -100,13 +101,23 @@ class PlatformStatsSummaryJobTest extends TestCase
             ]);  
         }
         $stats = [
-            [   // inactive
+            [   // inactive but recent enough to have a lastEdit
                 "wiki" => "wiki1.com",
-                "edits" => NULL,
-                "pages" => NULL,
-                "users" => NULL,
+                "edits" => 1,
+                "pages" => 1,
+                "users" => 1,
                 "active_users" => NULL,
-                "lastEdit" => Carbon::now()->subDays(90)->timestamp,
+                "lastEdit" => Carbon::now()->subDays(100)->timestamp,
+                "first100UsingOauth" => "0",
+                "platform_summary_version" => "v1"
+            ],
+            [   // inactive but so old that mediawiki reports no last edit
+                "wiki" => "wiki5.com",
+                "edits" => 1,
+                "pages" => 1,
+                "users" => 1,
+                "active_users" => NULL,
+                "lastEdit" => NULL,
                 "first100UsingOauth" => "0",
                 "platform_summary_version" => "v1"
             ],
@@ -149,15 +160,15 @@ class PlatformStatsSummaryJobTest extends TestCase
     
        $this->assertEquals(
             [
-                "total" => 4,
+                "total" => 5,
                 "deleted" => 1,
                 "active" => 1,
-                "inactive" => 1,
+                "inactive" => 2,
                 "empty" => 1,
-                "total_non_deleted_users" => 3,
+                "total_non_deleted_users" => 5,
                 "total_non_deleted_active_users" => 1,
-                "total_non_deleted_pages" => 2,
-                "total_non_deleted_edits" => 1,
+                "total_non_deleted_pages" => 4,
+                "total_non_deleted_edits" => 3,
                 "platform_summary_version" => "v1"
             ],
             $groups, 


### PR DESCRIPTION
It appears since we created this job that we didn't properly handle the situation where there most recent revision isn't found for some reason. In this case we should assume that it hasn't been edited recently.

This could have happened since we updated mediawiki causing a change in the behaviour of the revision table or it could always have been non-functional

We should follow up with not relying on directly querying the mediawiki db for these stats and trying to find a more stable public api for it.

Bug: T364452