### PR TITLE
fix: Use MWTimestamps PlatformStatsSummaryJob

### DIFF
--- a/app/Helper/MWTimestampHelper.php
+++ b/app/Helper/MWTimestampHelper.php
@@ -1,0 +1,27 @@
+<?php
+
+/* The purpose of this class is to help convert between Carbon objects
+* used in this Platform API application and MWTimestamps which are used
+* internally in some Mediawiki databases.
+* See: https://www.mediawiki.org/wiki/Manual:Timestamp
+*/
+
+namespace App\Helper;
+use Carbon\CarbonImmutable;
+
+class MWTimestampHelper {
+
+    private const MWTimestampFormat = 'YmdHis';
+
+    static public function getCarbonFromMWTimestamp( string $MWTimestamp ): CarbonImmutable {
+        $carbon = CarbonImmutable::createFromFormat( self::MWTimestampFormat, $MWTimestamp );
+        if ($carbon === false) {
+            throw new \Exception('Unable to create Carbon object');
+        }
+        return $carbon;
+    }
+
+    static public function getMWTimestampFromCarbon(CarbonImmutable $carbonImmutable): string {
+        return $carbonImmutable->format(self::MWTimestampFormat);
+    }
+}

--- a/tests/Helper/MWTimestampHelperTest.php
+++ b/tests/Helper/MWTimestampHelperTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Helper\MWTimestampHelper;
+use Carbon\CarbonImmutable;
+use Carbon\Exceptions\InvalidFormatException;
+use PHPUnit\Framework\TestCase;
+
+class MWTimestampHelperTest extends TestCase
+{
+    public function testGetCarbonFromMWTimestamp()
+    {
+        $mwTimestamp = '20240513123456';
+        $expectedCarbon = CarbonImmutable::create(2024, 5, 13, 12, 34, 56);
+
+        $carbon = MWTimestampHelper::getCarbonFromMWTimestamp($mwTimestamp);
+
+        $this->assertEquals($expectedCarbon, $carbon);
+    }
+
+    public function testGetCarbonFromMWTimestampWithInvalidTimestamp()
+    {
+        $this->expectException(InvalidFormatException::class);
+
+        $invalidMwTimestamp = 'invalid_timestamp';
+        MWTimestampHelper::getCarbonFromMWTimestamp($invalidMwTimestamp);
+    }
+
+    public function testGetCarbonFromMWTimestampWithUnixTimestamp()
+    {
+        $this->expectException(InvalidFormatException::class);
+
+        $UnixTimestamp = CarbonImmutable::now()->timestamp;
+        MWTimestampHelper::getCarbonFromMWTimestamp($UnixTimestamp);
+    }
+
+    public function testGetMWTimestampFromCarbon()
+    {
+        $carbon = CarbonImmutable::create(2024, 5, 13, 12, 34, 56);
+        $expectedMwTimestamp = '20240513123456';
+
+        $mwTimestamp = MWTimestampHelper::getMWTimestampFromCarbon($carbon);
+
+        $this->assertEquals($expectedMwTimestamp, $mwTimestamp);
+    }
+}

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -2,6 +2,8 @@
 
 namespace Tests\Jobs;
 
+use App\Helper\MWTimestampHelper;
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 use App\User;
@@ -85,7 +87,7 @@ class PlatformStatsSummaryJobTest extends TestCase
         $wikis = [
             Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki1.com' ] ),
             Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki2.com' ] ),
-            Wiki::factory()->create( [ 'deleted_at' => Carbon::now()->subDays(90)->timestamp, 'domain' => 'wiki3.com' ] ),
+            Wiki::factory()->create( [ 'deleted_at' => CarbonImmutable::now()->subDays(90)->timestamp, 'domain' => 'wiki3.com' ] ),
             Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki4.com' ] ),
             Wiki::factory()->create( [ 'deleted_at' => null, 'domain' => 'wiki5.com' ] )
         ];
@@ -107,7 +109,7 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "pages" => 1,
                 "users" => 1,
                 "active_users" => NULL,
-                "lastEdit" => Carbon::now()->subDays(100)->timestamp,
+                "lastEdit" => MWTimestampHelper::getMWTimestampFromCarbon(CarbonImmutable::now()->subDays(100)),
                 "first100UsingOauth" => "0",
                 "platform_summary_version" => "v1"
             ],
@@ -138,7 +140,7 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "pages" => 2,
                 "users" => 3,
                 "active_users" => 1,
-                "lastEdit" => Carbon::now()->timestamp,
+                "lastEdit" => MWTimestampHelper::getMWTimestampFromCarbon(CarbonImmutable::now()),
                 "first100UsingOauth" => "0",
                 "platform_summary_version" => "v1"
             ],
@@ -149,7 +151,7 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "pages" => 2,
                 "users" => 3,
                 "active_users" => 0,
-                "lastEdit" => Carbon::now()->timestamp,
+                "lastEdit" => MWTimestampHelper::getMWTimestampFromCarbon(CarbonImmutable::now()),
                 "first100UsingOauth" => "0",
                 "platform_summary_version" => "v1"
             ],


### PR DESCRIPTION
We appear to have overloooked that the DB format used for MW revisions saved in MariaDB uses a special
string MWTimestampFormat.

This patch uses a previously introduced helper for converting these to Carbon and then doing the necessary comparisons.

It still uses the pattern of querying the MW dbs by building a query from the api db which I believe in the medium term we would like to move away from.

It adjust some comments to make this pattern more
understandable.

Bug: T364452