### PR TITLE
feat: rename active/inactive wiki metrics

### DIFF
--- a/app/Jobs/PlatformStatsSummaryJob.php
+++ b/app/Jobs/PlatformStatsSummaryJob.php
@@ -68,8 +68,8 @@ class PlatformStatsSummaryJob extends Job
     public function prepareStats( array $allStats, $wikis): array {
 
         $deletedWikis = [];
-        $activeWikis = [];
-        $inactiveWikis = [];
+        $editedLast90DaysWikis = [];
+        $notEditedLast90DaysWikis = [];
         $emptyWikis = [];
         $nonDeletedStats = [];
         $itemsCount = [];
@@ -112,19 +112,19 @@ class PlatformStatsSummaryJob extends Job
 
             $nonDeletedStats[] = $stats;
 
-            // is it active?
+            // is it edited in the last 90 days?
             if(!is_null($stats['lastEdit'])){
                 $lastTimestamp = MWTimestampHelper::getCarbonFromMWTimestamp(intVal($stats['lastEdit']));
                 $diff = $lastTimestamp->diffInSeconds($currentTime);
 
                 if ($diff <= $this->inactiveThreshold) {
-                    $activeWikis[] = $wiki;
+                    $editedLast90DaysWikis[] = $wiki;
                     continue;
                 }
             }
 
-            // if it's neither deleted, empty or active it must be inactive
-            $inactiveWikis[] = $wiki;
+            // if it's neither deleted, empty or active it must not be edited in the last 90 days
+            $notEditedLast90DaysWikis[] = $wiki;
         }
 
         $totalNonDeletedUsers = array_sum(array_column($nonDeletedStats, 'users'));
@@ -138,8 +138,8 @@ class PlatformStatsSummaryJob extends Job
             'platform_summary_version' => $this->platformSummaryStatsVersion,
             'total' => count($wikis),
             'deleted' => count($deletedWikis),
-            'active' => count($activeWikis),
-            'inactive' => count($inactiveWikis),
+            'edited_last_90_days' => count($editedLast90DaysWikis),
+            'not_edited_last_90_days' => count($notEditedLast90DaysWikis),
             'empty' => count($emptyWikis),
             'total_non_deleted_users' => $totalNonDeletedUsers,
             'total_non_deleted_active_users' => $totalNonDeletedActiveUsers,

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -143,7 +143,7 @@ class PlatformStatsSummaryJobTest extends TestCase
         }
 
         $stats = [
-            [   // inactive but recent enough to have a lastEdit
+            [   // no edits in last 90days but recent enough to have a lastEdit
                 "wiki" => "wiki1.com",
                 "edits" => 1,
                 "pages" => 1,
@@ -153,7 +153,7 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "first100UsingOauth" => "0",
                 "platform_summary_version" => "v1"
             ],
-            [   // inactive but so old that mediawiki reports no last edit
+            [   // no edits in last 90 days so old that mediawiki reports no last edit
                 "wiki" => "wiki5.com",
                 "edits" => 1,
                 "pages" => 1,
@@ -174,7 +174,7 @@ class PlatformStatsSummaryJobTest extends TestCase
                 "platform_summary_version" => "v1"
             ],
 
-            [   // active
+            [   // edited within last 90 days
                 "wiki" => "wiki4.com",
                 "edits" => 1,
                 "pages" => 2,
@@ -203,8 +203,8 @@ class PlatformStatsSummaryJobTest extends TestCase
             [
                 "total" => 5,
                 "deleted" => 1,
-                "active" => 1,
-                "inactive" => 2,
+                "edited_last_90_days" => 1,
+                "not_edited_last_90_days" => 2,
                 "empty" => 1,
                 "total_non_deleted_users" => 5,
                 "total_non_deleted_active_users" => 1,


### PR DESCRIPTION
There was some ambiguity about the meaning of
active and inactive so this commit more verbosely
renames them to exactly what they are: edited (or
not) in the last 90 days.

There is still a very mild unclarity in the name
not_edited_last_90_days because this excludes
empty wikis not edited in the last 90 days.

because not_edited_last_90_days_but_not_empty
seemed ludicrous.

Bug: T364452