### PR TITLE
fix(stats): namespace ids for counts are flipped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 10x.8.1 - 16 May 2024
+- Fix flipped namespace ids in PlatformSummaryStatsJob
+
 ## 10x.8.0 - 15 May 2024
 - PlatformSummaryStatsJob adjust metric names
 

--- a/app/Jobs/PlatformStatsSummaryJob.php
+++ b/app/Jobs/PlatformStatsSummaryJob.php
@@ -38,8 +38,8 @@ class PlatformStatsSummaryJob extends Job
 
     private $platformSummaryStatsVersion = "v1";
 
-    private const NAMESPACE_ITEM = 122;
-    private const NAMESPACE_PROPERTY = 120;
+    private const NAMESPACE_ITEM = 120;
+    private const NAMESPACE_PROPERTY = 122;
 
     public function __construct() {
         $this->inactiveThreshold = Config::get('wbstack.platform_summary_inactive_threshold');
@@ -85,8 +85,18 @@ class PlatformStatsSummaryJob extends Job
             }
 
             //add items and properties counts of the wiki to the corresponded arrays
-            array_push($itemsCount, count($this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_ITEM)));
-            array_push($propertiesCount, count($this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_PROPERTY)));
+            try {
+                $nextItemCount = count($this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_ITEM));
+                array_push($itemsCount, $nextItemCount);
+            } catch (\Exception $ex) {
+                Log::warning("Failed to fetch item count for wiki ".$wiki->domain.", will use 0 instead.");
+            }
+            try {
+                $nextPropertyCount = count($this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_PROPERTY));
+                array_push($propertiesCount, $nextPropertyCount);
+            } catch (\Exception $ex) {
+                Log::warning("Failed to fetch property count for wiki ".$wiki->domain.", will use 0 instead.");
+            }
 
             $wikiDb = $wiki->wikiDb()->first();
 

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -106,36 +106,36 @@ class PlatformStatsSummaryJobTest extends TestCase
             ]);
             //Generate some items/properties for testing, each wiki will have 3 props and 9 items
             Http::fake([
-                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=&aplimit=max&format=json' => Http::response([
+                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=&aplimit=max&format=json' => Http::response([
                     'query' => [
                         'allpages' => [
-                            ['title' => 'Property:P1', 'namespace' => 120],
-                            ['title' => 'Property:P9', 'namespace' => 120],
-                            ['title' => 'Property:P11', 'namespace' => 120],
+                            ['title' => 'Property:P1', 'namespace' => 122],
+                            ['title' => 'Property:P9', 'namespace' => 122],
+                            ['title' => 'Property:P11', 'namespace' => 122],
                         ],
                     ],
                 ], 200),
-                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=&aplimit=max&format=json' => Http::response([
+                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=&aplimit=max&format=json' => Http::response([
                     'continue' => [
                         'apcontinue' => 'Q6',
                     ],
                     'query' => [
                         'allpages' => [
-                            ['title' => 'Item:Q1', 'namespace' => 122],
-                            ['title' => 'Item:Q2', 'namespace' => 122],
-                            ['title' => 'Item:Q3', 'namespace' => 122],
-                            ['title' => 'Item:Q4', 'namespace' => 122],
-                            ['title' => 'Item:Q5', 'namespace' => 122],
+                            ['title' => 'Item:Q1', 'namespace' => 120],
+                            ['title' => 'Item:Q2', 'namespace' => 120],
+                            ['title' => 'Item:Q3', 'namespace' => 120],
+                            ['title' => 'Item:Q4', 'namespace' => 120],
+                            ['title' => 'Item:Q5', 'namespace' => 120],
                         ],
                     ],
                 ], 200),
-                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=Q6&aplimit=max&format=json' => Http::response([
+                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=Q6&aplimit=max&format=json' => Http::response([
                     'query' => [
                         'allpages' => [
-                            ['title' => 'Item:Q6', 'namespace' => 122],
-                            ['title' => 'Item:Q7', 'namespace' => 122],
-                            ['title' => 'Item:Q8', 'namespace' => 122],
-                            ['title' => 'Item:Q9', 'namespace' => 122],
+                            ['title' => 'Item:Q6', 'namespace' => 120],
+                            ['title' => 'Item:Q7', 'namespace' => 120],
+                            ['title' => 'Item:Q8', 'namespace' => 120],
+                            ['title' => 'Item:Q9', 'namespace' => 120],
                         ],
                     ]
                 ], 200)


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T314481

We noticed the numbers for item and property count look off, and investigation shows this is because the namespace ids were wrongly mapped. This PR rectifies the mapping.

It also adds some error handling for networked actions, allowing for some calls to fail, else we'll end up with no metrics on a single network hiccup.