### PR TITLE
refactor: introduce namespace enum

### DIFF
--- a/app/Console/Commands/RebuildQueryserviceData.php
+++ b/app/Console/Commands/RebuildQueryserviceData.php
@@ -2,6 +2,7 @@
 
 namespace App\Console\Commands;
 
+use App\Constants\MediawikiNamespace;
 use App\Traits;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Http;
@@ -15,10 +16,6 @@ use App\Jobs\SpawnQueryserviceUpdaterJob;
 class RebuildQueryserviceData extends Command
 {
     use Traits\PageFetcher;
-
-    private const NAMESPACE_ITEM = 120;
-    private const NAMESPACE_PROPERTY = 122;
-    private const NAMESPACE_LEXEME = 146;
 
     protected $signature = 'wbs-qs:rebuild {--domain=*} {--chunkSize=50} {--queueName=manual-intervention} {--sparqlUrlFormat=http://queryservice.default.svc.cluster.local:9999/bigdata/namespace/%s/sparql}';
 
@@ -80,8 +77,8 @@ class RebuildQueryserviceData extends Command
 
     private function getEntitiesForWiki (Wiki $wiki): array
     {
-        $items = $this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_ITEM);
-        $properties = $this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_PROPERTY);
+        $items = $this->fetchPagesInNamespace($wiki->domain, MediawikiNamespace::item);
+        $properties = $this->fetchPagesInNamespace($wiki->domain, MediawikiNamespace::property);
 
         $lexemesSetting = WikiSetting::where(
             [
@@ -91,7 +88,7 @@ class RebuildQueryserviceData extends Command
         )->first();
         $hasLexemesEnabled = $lexemesSetting !== null && $lexemesSetting->value === '1';
         $lexemes = $hasLexemesEnabled
-            ? $this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_LEXEME)
+            ? $this->fetchPagesInNamespace($wiki->domain, MediawikiNamespace::lexeme)
             : [];
 
         $merged = array_merge($items, $properties, $lexemes);

--- a/app/Constants/MediawikiNamespace.php
+++ b/app/Constants/MediawikiNamespace.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace App\Constants;
+
+enum MediawikiNamespace: int {
+    case item = 120;
+    case property = 122;
+    case lexeme = 146;
+}

--- a/app/Jobs/CreateQueryserviceBatchesJob.php
+++ b/app/Jobs/CreateQueryserviceBatchesJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Constants\MediawikiNamespace;
 use App\EventPageUpdate;
 use App\QsBatch;
 use App\QsCheckpoint;
@@ -12,10 +13,6 @@ use Illuminate\Support\Collection;
 
 class CreateQueryserviceBatchesJob extends Job
 {
-    private const NAMESPACE_ITEM = 120;
-    private const NAMESPACE_PROPERTY = 122;
-    private const NAMESPACE_LEXEME = 146;
-
     private int $entityLimit;
 
     public $timeout = 3600;
@@ -58,7 +55,7 @@ class CreateQueryserviceBatchesJob extends Job
         EventPageUpdate::where(
             'id', '>', $latestCheckpoint,
         )
-            ->whereIn('namespace', [self::NAMESPACE_ITEM, self::NAMESPACE_PROPERTY, self::NAMESPACE_LEXEME])
+            ->whereIn('namespace', [MediawikiNamespace::item, MediawikiNamespace::property, MediawikiNamespace::lexeme])
             ->has('wiki')
             ->chunk(100, function (Collection $chunk) use (&$newEntitiesFromEvents, &$latestEventId) {
                 foreach ($chunk as $event) {

--- a/app/Jobs/PlatformStatsSummaryJob.php
+++ b/app/Jobs/PlatformStatsSummaryJob.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Constants\MediawikiNamespace;
 use App\Traits;
 use App\Helper\MWTimestampHelper;
 use App\Wiki;
@@ -37,9 +38,6 @@ class PlatformStatsSummaryJob extends Job
     private $creationRateRanges;
 
     private $platformSummaryStatsVersion = "v1";
-
-    private const NAMESPACE_ITEM = 120;
-    private const NAMESPACE_PROPERTY = 122;
 
     public function __construct() {
         $this->inactiveThreshold = Config::get('wbstack.platform_summary_inactive_threshold');
@@ -86,13 +84,13 @@ class PlatformStatsSummaryJob extends Job
 
             //add items and properties counts of the wiki to the corresponded arrays
             try {
-                $nextItemCount = count($this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_ITEM));
+                $nextItemCount = count($this->fetchPagesInNamespace($wiki->domain, MediawikiNamespace::item));
                 array_push($itemsCount, $nextItemCount);
             } catch (\Exception $ex) {
                 Log::warning("Failed to fetch item count for wiki ".$wiki->domain.", will use 0 instead.");
             }
             try {
-                $nextPropertyCount = count($this->fetchPagesInNamespace($wiki->domain, self::NAMESPACE_PROPERTY));
+                $nextPropertyCount = count($this->fetchPagesInNamespace($wiki->domain, MediawikiNamespace::property));
                 array_push($propertiesCount, $nextPropertyCount);
             } catch (\Exception $ex) {
                 Log::warning("Failed to fetch property count for wiki ".$wiki->domain.", will use 0 instead.");

--- a/app/Traits/PageFetcher.php
+++ b/app/Traits/PageFetcher.php
@@ -2,6 +2,7 @@
 
 namespace App\Traits;
 
+use App\Constants\MediawikiNamespace;
 use Illuminate\Support\Facades\Http;
 
 trait PageFetcher
@@ -9,7 +10,7 @@ trait PageFetcher
     private string $apiUrl;
 
     //this function is used to fetch pages on namespace
-    function fetchPagesInNamespace(string $wikiDomain, int $namespace): array
+    function fetchPagesInNamespace(string $wikiDomain, MediawikiNamespace $namespace): array
     {
         if (empty($this->apiUrl)) {
             throw new \RuntimeException('API URL has not been set.');
@@ -25,7 +26,7 @@ trait PageFetcher
                 [
                     'action' => 'query',
                     'list' => 'allpages',
-                    'apnamespace' => $namespace,
+                    'apnamespace' => $namespace->value,
                     'apcontinue' => $cursor,
                     'aplimit' => 'max',
                     'format' => 'json',

--- a/tests/Commands/RebuildQueryserviceDataTest.php
+++ b/tests/Commands/RebuildQueryserviceDataTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Commands;
 
+use App\Constants\MediawikiNamespace;
 use App\Wiki;
 use App\QueryserviceNamespace;
 use App\WikiSetting;
@@ -59,25 +60,25 @@ class RebuildQueryserviceDataTest extends TestCase
         ]);
 
         Http::fake([
-            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=&aplimit=max&format=json' => Http::response([
+            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=&aplimit=max&format=json' => Http::response([
                 'query' => [
                     'allpages' => [
                         [
                             'title' => 'Property:P1',
-                            'namespace' => 120,
+                            'namespace' => MediawikiNamespace::property,
                         ],
                         [
                             'title' => 'Property:P9',
-                            'namespace' => 120,
+                            'namespace' => MediawikiNamespace::property,
                         ],
                         [
                             'title' => 'Property:P11',
-                            'namespace' => 120,
+                            'namespace' => MediawikiNamespace::property,
                         ],
                     ],
                 ],
             ], 200),
-            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=&aplimit=max&format=json' => Http::response([
+            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=&aplimit=max&format=json' => Http::response([
                 'continue' => [
                     'apcontinue' => 'Q6',
                 ],
@@ -85,45 +86,45 @@ class RebuildQueryserviceDataTest extends TestCase
                     'allpages' => [
                         [
                             'title' => 'Item:Q1',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q2',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q3',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q4',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q5',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                     ],
                 ],
             ], 200),
-            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=Q6&aplimit=max&format=json' => Http::response([
+            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=Q6&aplimit=max&format=json' => Http::response([
                 'query' => [
                     'allpages' => [
                         [
                             'title' => 'Item:Q6',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q7',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q8',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q9',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                     ],
                 ]
@@ -188,46 +189,46 @@ class RebuildQueryserviceDataTest extends TestCase
         ]);
 
         Http::fake([
-            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=&aplimit=max&format=json' => Http::response([
-                'query' => [
-                    'allpages' => [
-                        [
-                            'title' => 'Property:P1',
-                            'namespace' => 120,
-                        ],
-                        [
-                            'title' => 'Property:P9',
-                            'namespace' => 120,
-                        ],
-                        [
-                            'title' => 'Property:P11',
-                            'namespace' => 120,
-                        ],
-                    ],
-                ],
-            ], 200),
             getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=&aplimit=max&format=json' => Http::response([
                 'query' => [
                     'allpages' => [
                         [
+                            'title' => 'Property:P1',
+                            'namespace' => MediawikiNamespace::property,
+                        ],
+                        [
+                            'title' => 'Property:P9',
+                            'namespace' => MediawikiNamespace::property,
+                        ],
+                        [
+                            'title' => 'Property:P11',
+                            'namespace' => MediawikiNamespace::property,
+                        ],
+                    ],
+                ],
+            ], 200),
+            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=&aplimit=max&format=json' => Http::response([
+                'query' => [
+                    'allpages' => [
+                        [
                             'title' => 'Item:Q1',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q2',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q3',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q4',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                         [
                             'title' => 'Item:Q5',
-                            'namespace' => 122,
+                            'namespace' => MediawikiNamespace::item,
                         ],
                     ],
                 ],
@@ -264,20 +265,20 @@ class RebuildQueryserviceDataTest extends TestCase
         ]);
 
         Http::fake([
-            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=&aplimit=max&format=json' => Http::response([
+            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=&aplimit=max&format=json' => Http::response([
                 'query' => [
                     'allpages' => [
                         [
                             'title' => 'Property:P1',
-                            'namespace' => 120,
+                            'namespace' => MediawikiNamespace::property,
                         ],
                         [
                             'title' => 'Property:P9',
-                            'namespace' => 120,
+                            'namespace' => MediawikiNamespace::property,
                         ],
                         [
                             'title' => 'Property:P11',
-                            'namespace' => 120,
+                            'namespace' => MediawikiNamespace::property,
                         ],
                     ],
                 ],

--- a/tests/Jobs/CreateQueryserviceBatchesJobTest.php
+++ b/tests/Jobs/CreateQueryserviceBatchesJobTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Jobs;
 
+use App\Constants\MediawikiNamespace;
 use App\QsBatch;
 use App\QsCheckpoint;
 use App\Wiki;
@@ -59,13 +60,13 @@ class CreateQueryserviceBatchesJobTest extends TestCase
         QsBatch::factory()->create(['id' => 1, 'done' => 0, 'wiki_id' => 88, 'entityIds' => 'Q23,P1']);
         QsBatch::factory()->create(['id' => 2, 'done' => 0, 'wiki_id' => 99, 'entityIds' => 'Q99,Q100']);
         QsCheckpoint::set(2);
-        EventPageUpdate::factory()->create(['id' => 1, 'wiki_id' => 111, 'namespace' => 120, 'title' => 'Q21']);
-        EventPageUpdate::factory()->create(['id' => 3, 'wiki_id' => 111, 'namespace' => 120, 'title' => 'Q12']);
+        EventPageUpdate::factory()->create(['id' => 1, 'wiki_id' => 111, 'namespace' => MediawikiNamespace::item, 'title' => 'Q21']);
+        EventPageUpdate::factory()->create(['id' => 3, 'wiki_id' => 111, 'namespace' => MediawikiNamespace::item, 'title' => 'Q12']);
         EventPageUpdate::factory()->create(['id' => 4, 'wiki_id' => 111, 'namespace' => 999, 'title' => 'Q999']);
         // This is a duplicate and should therefore only show up once
-        EventPageUpdate::factory()->create(['id' => 5, 'wiki_id' => 111, 'namespace' => 120, 'title' => 'Q12']);
+        EventPageUpdate::factory()->create(['id' => 5, 'wiki_id' => 111, 'namespace' => MediawikiNamespace::item, 'title' => 'Q12']);
         // This is a deleted wiki and should create a batch
-        EventPageUpdate::factory()->create(['id' => 6, 'wiki_id' => 1, 'namespace' => 120, 'title' => 'Q152']);
+        EventPageUpdate::factory()->create(['id' => 6, 'wiki_id' => 1, 'namespace' => MediawikiNamespace::item, 'title' => 'Q152']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();
@@ -90,8 +91,8 @@ class CreateQueryserviceBatchesJobTest extends TestCase
         Wiki::factory()->create(['id' => 111, 'domain' => 'test3.wikibase.cloud']);
         QsBatch::factory()->create(['id' => 1, 'done' => 0, 'wiki_id' => 88, 'entityIds' => 'Q23,P1']);
         QsBatch::factory()->create(['id' => 2, 'done' => 0, 'wiki_id' => 99, 'entityIds' => 'Q99,Q100']);
-        EventPageUpdate::factory()->create(['id' => 123, 'wiki_id' => 111, 'namespace' => 120, 'title' => 'Q12']);
-        EventPageUpdate::factory()->create(['id' => 234, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q34']);
+        EventPageUpdate::factory()->create(['id' => 123, 'wiki_id' => 111, 'namespace' => MediawikiNamespace::item, 'title' => 'Q12']);
+        EventPageUpdate::factory()->create(['id' => 234, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q34']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();
@@ -111,14 +112,14 @@ class CreateQueryserviceBatchesJobTest extends TestCase
     {
         Wiki::factory()->create(['id' => 88, 'domain' => 'test1.wikibase.cloud']);
         QsBatch::factory()->create(['id' => 1, 'done' => 0, 'wiki_id' => 88, 'entityIds' => 'Q1,Q2,Q3,Q4,Q5,Q6,Q7,Q8,Q9,Q10']);
-        EventPageUpdate::factory()->create(['id' => 123, 'wiki_id' => 88, 'namespace' => 120, 'title' => 'Q11']);
+        EventPageUpdate::factory()->create(['id' => 123, 'wiki_id' => 88, 'namespace' => MediawikiNamespace::item, 'title' => 'Q11']);
 
         Wiki::factory()->create(['id' => 99, 'domain' => 'test2.wikibase.cloud']);
         QsBatch::factory()->create(['id' => 2, 'done' => 0, 'wiki_id' => 99, 'entityIds' => 'Q1,Q2,Q3,Q4,Q5,Q6,Q7,Q8,Q9,Q10']);
         QsBatch::factory()->create(['id' => 3, 'done' => 0, 'wiki_id' => 99, 'entityIds' => 'P1,P2,P3,P4,P5,P6,P7,P8,P9,P10']);
         QsBatch::factory()->create(['id' => 4, 'done' => 0, 'wiki_id' => 99, 'entityIds' => 'Q12']);
         QsBatch::factory()->create(['id' => 5, 'done' => 0, 'wiki_id' => 99, 'entityIds' => 'P11,P12,P13,P14,P15,P16,P17,P18,P19,P20']);
-        EventPageUpdate::factory()->create(['id' => 124, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q11']);
+        EventPageUpdate::factory()->create(['id' => 124, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q11']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();
@@ -143,7 +144,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase
         $this->assertEquals($existingBatches->values()->get(3)->entityIds, 'P11,P12,P13,P14,P15,P16,P17,P18,P19,P20');
 
         // Test if we prevent items from being fed into the updater multiple times
-        EventPageUpdate::factory()->create(['id' => 125, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q999']);
+        EventPageUpdate::factory()->create(['id' => 125, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q999']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();
@@ -160,17 +161,17 @@ class CreateQueryserviceBatchesJobTest extends TestCase
     function testBackpressure(): void
     {
         Wiki::factory()->create(['id' => 99, 'domain' => 'test.wikibase.cloud']);
-        EventPageUpdate::factory()->create(['id' => 124, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q1']);
-        EventPageUpdate::factory()->create(['id' => 125, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q2']);
-        EventPageUpdate::factory()->create(['id' => 126, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q3']);
-        EventPageUpdate::factory()->create(['id' => 127, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q4']);
-        EventPageUpdate::factory()->create(['id' => 128, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q5']);
-        EventPageUpdate::factory()->create(['id' => 129, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q6']);
-        EventPageUpdate::factory()->create(['id' => 130, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q7']);
-        EventPageUpdate::factory()->create(['id' => 131, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q8']);
-        EventPageUpdate::factory()->create(['id' => 132, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q9']);
-        EventPageUpdate::factory()->create(['id' => 133, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q11']);
-        EventPageUpdate::factory()->create(['id' => 134, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q12']);
+        EventPageUpdate::factory()->create(['id' => 124, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q1']);
+        EventPageUpdate::factory()->create(['id' => 125, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q2']);
+        EventPageUpdate::factory()->create(['id' => 126, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q3']);
+        EventPageUpdate::factory()->create(['id' => 127, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q4']);
+        EventPageUpdate::factory()->create(['id' => 128, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q5']);
+        EventPageUpdate::factory()->create(['id' => 129, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q6']);
+        EventPageUpdate::factory()->create(['id' => 130, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q7']);
+        EventPageUpdate::factory()->create(['id' => 131, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q8']);
+        EventPageUpdate::factory()->create(['id' => 132, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q9']);
+        EventPageUpdate::factory()->create(['id' => 133, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q11']);
+        EventPageUpdate::factory()->create(['id' => 134, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q12']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();
@@ -185,16 +186,16 @@ class CreateQueryserviceBatchesJobTest extends TestCase
     function testCheckpoints(): void
     {
         Wiki::factory()->create(['id' => 99, 'domain' => 'test.wikibase.cloud']);
-        EventPageUpdate::factory()->create(['id' => 124, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q1']);
-        EventPageUpdate::factory()->create(['id' => 125, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q2']);
-        EventPageUpdate::factory()->create(['id' => 126, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q3']);
-        EventPageUpdate::factory()->create(['id' => 127, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q4']);
-        EventPageUpdate::factory()->create(['id' => 128, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q5']);
-        EventPageUpdate::factory()->create(['id' => 131, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q8']);
-        EventPageUpdate::factory()->create(['id' => 132, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q9']);
-        EventPageUpdate::factory()->create(['id' => 133, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q11']);
-        EventPageUpdate::factory()->create(['id' => 134, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q12']);
-        EventPageUpdate::factory()->create(['id' => 188, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q12']);
+        EventPageUpdate::factory()->create(['id' => 124, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q1']);
+        EventPageUpdate::factory()->create(['id' => 125, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q2']);
+        EventPageUpdate::factory()->create(['id' => 126, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q3']);
+        EventPageUpdate::factory()->create(['id' => 127, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q4']);
+        EventPageUpdate::factory()->create(['id' => 128, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q5']);
+        EventPageUpdate::factory()->create(['id' => 131, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q8']);
+        EventPageUpdate::factory()->create(['id' => 132, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q9']);
+        EventPageUpdate::factory()->create(['id' => 133, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q11']);
+        EventPageUpdate::factory()->create(['id' => 134, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q12']);
+        EventPageUpdate::factory()->create(['id' => 188, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q12']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();
@@ -205,8 +206,8 @@ class CreateQueryserviceBatchesJobTest extends TestCase
 
         $this->assertEquals(188, QsCheckpoint::where(['id' => QsCheckpoint::CHECKPOINT_ID])->first()->checkpoint);
 
-        EventPageUpdate::factory()->create(['id' => 199, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q127']);
-        EventPageUpdate::factory()->create(['id' => 198, 'wiki_id' => 99, 'namespace' => 120, 'title' => 'Q126']);
+        EventPageUpdate::factory()->create(['id' => 199, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q127']);
+        EventPageUpdate::factory()->create(['id' => 198, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q126']);
 
         $mockJob = $this->createMock(Job::class);
         $job = new CreateQueryserviceBatchesJob();

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Jobs;
 
+use App\Constants\MediawikiNamespace;
 use App\Helper\MWTimestampHelper;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
@@ -109,9 +110,9 @@ class PlatformStatsSummaryJobTest extends TestCase
                 getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=122&apcontinue=&aplimit=max&format=json' => Http::response([
                     'query' => [
                         'allpages' => [
-                            ['title' => 'Property:P1', 'namespace' => 122],
-                            ['title' => 'Property:P9', 'namespace' => 122],
-                            ['title' => 'Property:P11', 'namespace' => 122],
+                            ['title' => 'Property:P1', 'namespace' => MediawikiNamespace::property],
+                            ['title' => 'Property:P9', 'namespace' => MediawikiNamespace::property],
+                            ['title' => 'Property:P11', 'namespace' => MediawikiNamespace::property],
                         ],
                     ],
                 ], 200),
@@ -121,21 +122,21 @@ class PlatformStatsSummaryJobTest extends TestCase
                     ],
                     'query' => [
                         'allpages' => [
-                            ['title' => 'Item:Q1', 'namespace' => 120],
-                            ['title' => 'Item:Q2', 'namespace' => 120],
-                            ['title' => 'Item:Q3', 'namespace' => 120],
-                            ['title' => 'Item:Q4', 'namespace' => 120],
-                            ['title' => 'Item:Q5', 'namespace' => 120],
+                            ['title' => 'Item:Q1', 'namespace' => MediawikiNamespace::item],
+                            ['title' => 'Item:Q2', 'namespace' => MediawikiNamespace::item],
+                            ['title' => 'Item:Q3', 'namespace' => MediawikiNamespace::item],
+                            ['title' => 'Item:Q4', 'namespace' => MediawikiNamespace::item],
+                            ['title' => 'Item:Q5', 'namespace' => MediawikiNamespace::item],
                         ],
                     ],
                 ], 200),
                 getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=allpages&apnamespace=120&apcontinue=Q6&aplimit=max&format=json' => Http::response([
                     'query' => [
                         'allpages' => [
-                            ['title' => 'Item:Q6', 'namespace' => 120],
-                            ['title' => 'Item:Q7', 'namespace' => 120],
-                            ['title' => 'Item:Q8', 'namespace' => 120],
-                            ['title' => 'Item:Q9', 'namespace' => 120],
+                            ['title' => 'Item:Q6', 'namespace' => MediawikiNamespace::item],
+                            ['title' => 'Item:Q7', 'namespace' => MediawikiNamespace::item],
+                            ['title' => 'Item:Q8', 'namespace' => MediawikiNamespace::item],
+                            ['title' => 'Item:Q9', 'namespace' => MediawikiNamespace::item],
                         ],
                     ]
                 ], 200)


### PR DESCRIPTION
In order to reduce the chance of future mixups lets use an enum for mediawiki namespaces. Athough these namespace ids are not actually globally fixed within the wikibase cloud and wbstack context we force them to be set this way.