### PR TITLE
hotfix: conversion metrics with duplicate lifecycle events

### DIFF
--- a/app/Http/Controllers/ConversionMetricController.php
+++ b/app/Http/Controllers/ConversionMetricController.php
@@ -20,15 +20,15 @@ class ConversionMetricController extends Controller
         $allWikis = Wiki::all();
         $current_date = CarbonImmutable::now();
         $output = [];
-        
+
 
         foreach ($allWikis as $wiki) {
-            $lifecycleEvents = $wiki->wikiLifecycleEvents()->first();
+            $lifecycleEvents = $wiki->wikiLifecycleEvents()->orderBy('id', 'desc')->first();
             $wikiLastEditedTime = null;
             $wikiFirstEditedTime = null;
             if (!empty($lifecycleEvents)  ) {
                 if ($lifecycleEvents['last_edited']) {
-                    $wikiLastEditedTime = CarbonImmutable::parse($lifecycleEvents['last_edited']);    
+                    $wikiLastEditedTime = CarbonImmutable::parse($lifecycleEvents['last_edited']);
                 }
                 if ($lifecycleEvents['first_edited']) {
                     $wikiFirstEditedTime = CarbonImmutable::parse($lifecycleEvents['first_edited']);


### PR DESCRIPTION
This is a very quick patch to fix conversion metrics when lifecycleEvents have unusually been duplicated.

It selects the latest object rather than the oldest.

This is not a permanent fix. That fix should actually resolve the race condition of multiple objects after cleaning them up.

Bug: T364991