### PR TITLE
fix: enforce unique lifecycle constraint per wiki on db level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 10x.8.4 - 19 June 2024
+- Enforce per-wiki-uniqueness for WikiLifecycleEvents on database level
+
 ## 10x.8.3 - 18 June 2024
 - Fix calculation of first edited date in site stats
 

--- a/app/Jobs/UpdateWikiSiteStatsJob.php
+++ b/app/Jobs/UpdateWikiSiteStatsJob.php
@@ -43,7 +43,9 @@ class UpdateWikiSiteStatsJob extends Job implements ShouldBeUnique
             $update['last_edited'] = Carbon::parse($lastEdited);
         }
 
-        $wiki->wikiLifecycleEvents()->updateOrCreate($update);
+        DB::transaction(function () use ($wiki, $update) {
+            $wiki->wikiLifecycleEvents()->lockForUpdate()->updateOrCreate(['wiki_id' => $wiki->id], $update);
+        });
     }
 
     private function updateSiteStats (Wiki $wiki): void

--- a/database/migrations/2024_06_19_110900_enforce_lifecycle_events_constraint.php
+++ b/database/migrations/2024_06_19_110900_enforce_lifecycle_events_constraint.php
@@ -1,0 +1,55 @@
+<?php
+
+use App\WikiLifecycleEvents;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use App\Wiki;
+
+class EnforceLifecycleEventsConstraint extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $allWikis = Wiki::query()->get();
+        // Albeit `createOrUpdate` was used when creating lifecycle events
+        // was used, multiple copies per wiki were created. To clean up before
+        // enforcing a unique constraint on database level, this migration
+        // deletes all duplicate rows, keeping the latest one only.
+        foreach ($allWikis as $wiki) {
+            $latestLifecycleEvent = WikiLifecycleEvents::where(['wiki_id' => $wiki->id])
+                ->latest()
+                ->take(1)
+                ->pluck('id');
+            WikiLifecycleEvents::where(['wiki_id' => $wiki->id])
+                ->whereNotIn('id', $latestLifecycleEvent)
+                ->delete();
+        }
+        // Now that there is a single row per wiki, we can enforce the unique
+        // constraint on database level.
+        Schema::table('wiki_lifecycle_events', function (Blueprint $table) {
+            $table->unique('wiki_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // foreign key constraints need to be disabled as per https://github.com/laravel/framework/issues/13873
+        Schema::disableForeignKeyConstraints();
+        Schema::table('wiki_lifecycle_events', function (Blueprint $table) {
+            // The column name HAS to be wrapped in an array so Laravel can
+            // figure out the relation name.
+            $table->dropUnique(['wiki_id']);
+        });
+        Schema::enableForeignKeyConstraints();
+    }
+}

--- a/tests/Routes/Wiki/ConversionMetricTest.php
+++ b/tests/Routes/Wiki/ConversionMetricTest.php
@@ -47,28 +47,6 @@ class ConversionMetricTest extends TestCase
         $response->assertSee('two.wikibase.cloud');
     }
 
-    public function testDownloadJsonWithDuplicateLifecycleEvents() {
-        $current_date = CarbonImmutable::now();
-        $wiki = $this->createTestWiki('one.wikibase.cloud', 10, 9, 2);
-        $wiki->wikiLifecycleEvents()->create([
-            'last_edited' => $current_date->subWeeks(1),
-            'first_edited' => $current_date->subWeeks(9)
-        ]);
-        $wiki->save();
-        $response = $this->getJson($this->route);
-        $response->assertStatus(200);
-        $response->assertJsonFragment(
-            [
-                'domain' => 'one.wikibase.cloud',
-                'time_to_engage_days' => 7,
-                'time_before_wiki_abandoned_days' => null,
-                'number_of_active_editors' => 0,
-                'first_edited_time' => $current_date->subWeeks(9),
-                'last_edited_time' => $current_date->subWeeks(1)
-            ]
-        );
-    }
-
     private function createTestWiki( $name, $createdWeeksAgo, $firstEditedWeeksAgo, $lastEditedWeeksAgo, $active_users = 0): Wiki {
         $current_date = CarbonImmutable::now();
 


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T364991, follows up on #808 

For whatever reason we currently create multiple event objects per wiki when all of the code is written with the assumption that this is a one to one relationship.

This PR adds:
- a migration that cleans up the existing data and enforces uniqueness at db level
- acquires a lock on the table before writing new objects