### PR TITLE
fix(migrations): consider deleted wikis when cleaning up lifecycle events table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 10x.8.5 - 19 June 2024
+- Consider deleted wikis when cleaning up lifecycle events table
+
 ## 10x.8.4 - 19 June 2024
 - Enforce per-wiki-uniqueness for WikiLifecycleEvents on database level
 

--- a/database/migrations/2024_06_19_110900_enforce_lifecycle_events_constraint.php
+++ b/database/migrations/2024_06_19_110900_enforce_lifecycle_events_constraint.php
@@ -15,7 +15,7 @@ class EnforceLifecycleEventsConstraint extends Migration
      */
     public function up()
     {
-        $allWikis = Wiki::query()->get();
+        $allWikis = Wiki::withTrashed()->get();
         // Albeit `createOrUpdate` was used when creating lifecycle events
         // was used, multiple copies per wiki were created. To clean up before
         // enforcing a unique constraint on database level, this migration


### PR DESCRIPTION
This is a fixup for #817 which did not consider wikis that have been deleted previously. Those wikis could still have dangling references to the lifecycle events table, so the unique constraint could not be applied:

```
In Connection.php line 824:
                                                                                                                                                                                                           
  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '647' for key 'wiki_lifecycle_events_wiki_id_unique' (Connection: mysql, SQL: alter table `wiki_lifecycle_events` add unique `wik  
  i_lifecycle_events_wiki_id_unique`(`wiki_id`))                                                                                                                                                           
                                                                                                                                                                                                           

In Connection.php line 587:
                                                                                                                              
  SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '647' for key 'wiki_lifecycle_events_wiki_id_unique'  
```