### PR TITLE
fix(wikistats): also exclude platform user from recentchanges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 10x.8.6 - 20 June 2024
+- Exclude PlatformReservedUser when looking up last edited date
+
 ## 10x.8.5 - 19 June 2024
 - Consider deleted wikis when cleaning up lifecycle events table
 

--- a/app/Jobs/UpdateWikiSiteStatsJob.php
+++ b/app/Jobs/UpdateWikiSiteStatsJob.php
@@ -119,6 +119,7 @@ class UpdateWikiSiteStatsJob extends Job implements ShouldBeUnique
                 'action' => 'query',
                 'list' => 'recentchanges',
                 'format' => 'json',
+                'rcexcludeuser' => 'PlatformReservedUser',
             ],
         );
         $result = data_get($recentChangesInfo->json(), 'query.recentchanges.0.timestamp');

--- a/tests/Jobs/UpdateWikiSiteStatsJobTest.php
+++ b/tests/Jobs/UpdateWikiSiteStatsJobTest.php
@@ -121,7 +121,7 @@ class UpdateWikiSiteStatsJobTest extends TestCase
                         ]
                     ]),
                 ],
-                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=recentchanges&format=json' => [
+                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=recentchanges&format=json&rcexcludeuser=PlatformReservedUser' => [
                     'this.wikibase.cloud' => Http::response([
                         'query' => [
                             'recentchanges' => [
@@ -284,7 +284,7 @@ class UpdateWikiSiteStatsJobTest extends TestCase
                     ]),
                     'that.wikibase.cloud' => Http::response([]),
                 ],
-                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=recentchanges&format=json' => [
+                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=recentchanges&format=json&rcexcludeuser=PlatformReservedUser' => [
                     'fail.wikibase.cloud' => Http::response([]),
                     'incomplete.wikibase.cloud' => Http::response('haha whoops', 500),
                     'that.wikibase.cloud' => Http::response([]),


### PR DESCRIPTION
This was missed in #814

The most recent changes could also be coming from the PlatformReservedUser (i.e. a freshly created wiki with no content), so it needs to be excluded here as well.