### PR TITLE
feat: add job for marking stalled entity imports as stalled

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,6 +13,7 @@ use App\Jobs\PollForMediaWikiJobsJob;
 use App\Jobs\UpdateWikiSiteStatsJob;
 use App\Jobs\SendEmptyWikiNotificationsJob;
 use App\Jobs\CreateQueryserviceBatchesJob;
+use App\Jobs\FailStalledEntityImportsJob;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
 
@@ -38,6 +39,7 @@ class Kernel extends ConsoleKernel
         $schedule->job(new PruneQueryserviceBatchesTable)->everyFifteenMinutes();
         $schedule->job(new CreateQueryserviceBatchesJob)->everyMinute();
         $schedule->job(new RequeuePendingQsBatchesJob)->everyFifteenMinutes();
+        $schedule->job(new FailStalledEntityImportsJob)->hourly();
 
         // Sandbox
         // TODO this should maybe only be run when sandbox as a whole is loaded?

--- a/app/Jobs/FailStalledEntityImportsJob.php
+++ b/app/Jobs/FailStalledEntityImportsJob.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs;
+
+use App\WikiEntityImportStatus;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use App\WikiEntityImport;
+
+class FailStalledEntityImportsJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+    public function handle(): void
+    {
+        $deadline = Carbon::now()->subHours(24);
+        $now = Carbon::now();
+
+        $stalledImports = WikiEntityImport::where([
+            ['status', '=', WikiEntityImportStatus::Pending],
+            ['started_at',  '<=', $deadline],
+        ]);
+        $stalledImports->update([
+            'status' => WikiEntityImportStatus::Failed,
+            'finished_at' => $now,
+        ]);
+
+        if ($stalledImports->count() > 0) {
+            Log::info(
+                "Marked ".$stalledImports->count()." WikiEntityImports as failed as they seem to be stalled."
+            );
+        }
+    }
+}

--- a/tests/Jobs/FailStalledEntityImportsJobTest.php
+++ b/tests/Jobs/FailStalledEntityImportsJobTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Tests\Jobs;
+
+use App\WikiEntityImportStatus;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Contracts\Queue\Job;
+use Carbon\Carbon;
+use App\Wiki;
+use App\WikiEntityImport;
+use App\Jobs\FailStalledEntityImportsJob;
+
+class FailStalledEntityImportsJobTest extends TestCase
+{
+
+    use RefreshDatabase;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        WikiEntityImport::query()->delete();
+        Wiki::query()->delete();
+    }
+
+    public function tearDown(): void
+    {
+        WikiEntityImport::query()->delete();
+        Wiki::query()->delete();
+        parent::tearDown();
+    }
+    public function testFailsEligible()
+    {
+        $wiki = Wiki::factory()->create(['domain' => 'test.wikibase.cloud']);
+        WikiEntityImport::factory()->create([
+            'wiki_id' => $wiki->id,
+            'status' => WikiEntityImportStatus::Pending,
+            'started_at' => Carbon::now()->subMinutes(60),
+        ]);
+        WikiEntityImport::factory()->create([
+            'wiki_id' => $wiki->id,
+            'status' => WikiEntityImportStatus::Pending,
+            'started_at' => Carbon::now()->subDays(4),
+        ]);
+        WikiEntityImport::factory()->create([
+            'wiki_id' => $wiki->id,
+            'status' => WikiEntityImportStatus::Success,
+            'started_at' => Carbon::now()->subDays(4),
+        ]);
+
+        $mockJob = $this->createMock(Job::class);
+        $mockJob->expects($this->never())->method('fail');
+
+        $job = new FailStalledEntityImportsJob();
+        $job->setJob($mockJob);
+        $job->handle();
+
+        $this->assertEquals(
+            1,
+            WikiEntityImport::where(['status' => WikiEntityImportStatus::Failed])->count(),
+        );
+        $this->assertEquals(
+            1,
+            WikiEntityImport::where(['status' => WikiEntityImportStatus::Pending])->count(),
+        );
+        $this->assertEquals(
+            1,
+            WikiEntityImport::where(['status' => WikiEntityImportStatus::Success])->count(),
+        );
+    }
+}


### PR DESCRIPTION
Ticket https://phabricator.wikimedia.org/T368021

This should have been included in #823 but wasn't.

If the Kubernetes jobs from #830 fail to signal back failure or success back to API for whatever, we should auto-sweep pending jobs as failed so people can at least try another import.