### PR TITLE
feat: tighten validation on entity parameters

### DIFF
--- a/app/Http/Controllers/WikiEntityImportController.php
+++ b/app/Http/Controllers/WikiEntityImportController.php
@@ -31,7 +31,14 @@ class WikiEntityImportController extends Controller
         $validatedInput = $request->validate([
             'wiki' => ['required', 'integer'],
             'source_wiki_url' => ['required', 'string'],
-            'entity_ids' => ['required', 'string'],
+            'entity_ids' => ['required', 'string', function (string $attr, mixed $value, \Closure $fail) {
+                $chunks = explode(',', $value);
+                foreach ($chunks as $chunk) {
+                    if (!preg_match("/^[A-Z]\d+$/", $chunk)) {
+                        $fail("Received unexpected input '{$chunk}' cannot continue.");
+                    }
+                }
+            }],
         ]);
 
         $wiki = Wiki::find($validatedInput['wiki']);


### PR DESCRIPTION
Ticket: https://phabricator.wikimedia.org/T368021

It occured to me these values, provided by the user will be passed to the `transferbot` image further down, opening a possible RCE vector. To prevent this, this PR adds validation that limits input to proper identifiers.