### PR TITLE
chore: allow for revisioned entity ids in validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 10.11.0 - 31 July 2024
+- Bump transferbot image, allow revisioned entity ids in validation
+
 ## 10.10.0 - 30 July 2024
 - Add Backend for Entity Import Feature T360031
 

--- a/app/Http/Controllers/WikiEntityImportController.php
+++ b/app/Http/Controllers/WikiEntityImportController.php
@@ -34,7 +34,7 @@ class WikiEntityImportController extends Controller
             'entity_ids' => ['required', 'string', function (string $attr, mixed $value, \Closure $fail) {
                 $chunks = explode(',', $value);
                 foreach ($chunks as $chunk) {
-                    if (!preg_match("/^[A-Z]\d+$/", $chunk)) {
+                    if (!preg_match("/^[A-Z]\d+(@\d+)?$/", $chunk)) {
                         $fail("Received unexpected input '{$chunk}' cannot continue.");
                     }
                 }

--- a/config/wbstack.php
+++ b/config/wbstack.php
@@ -36,5 +36,5 @@ return [
     'qs_job_namespace' => env('WBSTACK_QS_JOB_NAMESPACE', 'qs-jobs'),
 
     'transferbot_image_repo' => env('WBSTACK_TRANSFERBOT_IMAGE_REPO', 'ghcr.io/wbstack/transferbot'),
-    'transferbot_image_version' => env('WBSTACK_TRANSFERBOT_IMAGE_VERSION', '1.0.1'),
+    'transferbot_image_version' => env('WBSTACK_TRANSFERBOT_IMAGE_VERSION', '1.1.0'),
 ];

--- a/tests/Routes/Wiki/EntityImportTest.php
+++ b/tests/Routes/Wiki/EntityImportTest.php
@@ -135,7 +135,7 @@ class EntityImportTest extends TestCase
         WikiManager::factory()->create(['wiki_id' => $wiki->id, 'user_id' => $user->id]);
 
         $this->actingAs($user, 'api')
-            ->json('POST', $this->route.'?wiki='.$wiki->id, ['source_wiki_url' => 'https://source.wikibase.cloud', 'entity_ids' => 'P1,P2'])
+            ->json('POST', $this->route.'?wiki='.$wiki->id, ['source_wiki_url' => 'https://source.wikibase.cloud', 'entity_ids' => 'P1,P2,Q1@123'])
             ->assertStatus(200);
 
         $this->assertEquals(1, WikiEntityImport::count());
@@ -154,7 +154,7 @@ class EntityImportTest extends TestCase
             ->assertStatus(422);
 
         $this->assertEquals(0, WikiEntityImport::count());
-        Bus::assertDispatchedTimes(WikiEntityImportDummyJob::class, 0);
+        Bus::assertDispatchedTimes(WikiEntityImportJob::class, 0);
     }
     public function testCreateWhenFailed()
     {


### PR DESCRIPTION
Connects https://github.com/wbstack/transferbot/pull/6

When we want to pass revisioned ids to transferbot, current validation rules are too strict and need to allow for a potential `@123` suffix.