### PR TITLE
Normalised first and lasted edited time to use revisions

### DIFF
--- a/app/Jobs/UpdateWikiSiteStatsJob.php
+++ b/app/Jobs/UpdateWikiSiteStatsJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs;
 use App\Wiki;
 use App\WikiSiteStats;
 use Carbon\CarbonInterface;
+use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
@@ -14,6 +15,7 @@ use Carbon\Carbon;
 
 class UpdateWikiSiteStatsJob extends Job implements ShouldBeUnique
 {
+    use Dispatchable;
     public $timeout = 3600;
     public function handle (): void
     {

--- a/app/Jobs/UpdateWikiSiteStatsJob.php
+++ b/app/Jobs/UpdateWikiSiteStatsJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs;
 
 use App\Wiki;
 use App\WikiSiteStats;
+use Carbon\CarbonInterface;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\DB;
@@ -73,7 +74,7 @@ class UpdateWikiSiteStatsJob extends Job implements ShouldBeUnique
         });
     }
 
-    private function getFirstEditedDate (Wiki $wiki): ?\Carbon\CarbonInterface
+    private function getFirstEditedDate (Wiki $wiki): ?CarbonInterface
     {
         $allRevisions = Http::withHeaders(['host' => $wiki->getAttribute('domain')])->get(
             getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php',
@@ -111,18 +112,38 @@ class UpdateWikiSiteStatsJob extends Job implements ShouldBeUnique
         return Carbon::parse($result);
     }
 
-    private function getLastEditedDate (Wiki $wiki): ?\Carbon\CarbonInterface
+    private function getLastEditedDate (Wiki $wiki): ?CarbonInterface
     {
-        $recentChangesInfo = Http::withHeaders(['host' => $wiki->getAttribute('domain')])->get(
+        $allRevisions = Http::withHeaders(['host' => $wiki->getAttribute('domain')])->get(
             getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php',
             [
                 'action' => 'query',
-                'list' => 'recentchanges',
                 'format' => 'json',
-                'rcexcludeuser' => 'PlatformReservedUser',
+                'list' => 'allrevisions',
+                'formatversion' => 2,
+                'arvlimit' => 1,
+                'arvprop' => 'ids',
+                'arvexcludeuser' => 'PlatformReservedUser',
+                'arvdir' => 'older',
             ],
         );
-        $result = data_get($recentChangesInfo->json(), 'query.recentchanges.0.timestamp');
+        $lastRevision = data_get($allRevisions->json(), 'query.allrevisions.0.revisions.0.revid');
+        if (!$lastRevision) {
+            return null;
+        }
+
+        $revisionInfo = Http::withHeaders(['host' => $wiki->getAttribute('domain')])->get(
+            getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php',
+            [
+                'action' => 'query',
+                'format' => 'json',
+                'prop' => 'revisions',
+                'rvprop' => 'timestamp',
+                'formatversion' => 2,
+                'revids' => $lastRevision,
+            ],
+        );
+        $result = data_get($revisionInfo->json(), 'query.pages.0.revisions.0.timestamp');
         if (!$result) {
             return null;
         }

--- a/database/migrations/2024_08_01_193038_remove_and_rebuild_wiki_lifecycle_events.php
+++ b/database/migrations/2024_08_01_193038_remove_and_rebuild_wiki_lifecycle_events.php
@@ -1,0 +1,25 @@
+<?php
+
+use App\Jobs\UpdateWikiSiteStatsJob;
+use App\WikiLifecycleEvents;
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        WikiLifecycleEvents::all()->map->delete();
+        (new UpdateWikiSiteStatsJob())->handle();
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //
+    }
+};

--- a/database/migrations/2024_08_01_193038_remove_and_rebuild_wiki_lifecycle_events.php
+++ b/database/migrations/2024_08_01_193038_remove_and_rebuild_wiki_lifecycle_events.php
@@ -12,7 +12,7 @@ return new class extends Migration
     public function up(): void
     {
         WikiLifecycleEvents::query()->delete();
-        (new UpdateWikiSiteStatsJob())->handle();
+        UpdateWikiSiteStatsJob::dispatch();
     }
 
     /**

--- a/database/migrations/2024_08_01_193038_remove_and_rebuild_wiki_lifecycle_events.php
+++ b/database/migrations/2024_08_01_193038_remove_and_rebuild_wiki_lifecycle_events.php
@@ -11,7 +11,7 @@ return new class extends Migration
      */
     public function up(): void
     {
-        WikiLifecycleEvents::all()->map->delete();
+        WikiLifecycleEvents::query()->delete();
         (new UpdateWikiSiteStatsJob())->handle();
     }
 

--- a/tests/Jobs/UpdateWikiSiteStatsJobTest.php
+++ b/tests/Jobs/UpdateWikiSiteStatsJobTest.php
@@ -28,11 +28,12 @@ class UpdateWikiSiteStatsJobTest extends TestCase
 
     public function testSuccess()
     {
-        Wiki::factory()->create([
-            'domain' => 'this.wikibase.cloud'
-        ]);
+        
         Wiki::factory()->create([
             'domain' => 'that.wikibase.cloud'
+        ]);
+        Wiki::factory()->create([
+            'domain' => 'this.wikibase.cloud'
         ]);
 
         Http::fake(function (Request $request) {
@@ -93,6 +94,34 @@ class UpdateWikiSiteStatsJobTest extends TestCase
                         ]
                     ]),
                 ],
+                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&format=json&list=allrevisions&formatversion=2&arvlimit=1&arvprop=ids&arvexcludeuser=PlatformReservedUser&arvdir=older' => [
+                    'this.wikibase.cloud' => Http::response([
+                        'query' => [
+                            'allrevisions' => [
+                                [
+                                    'revisions' => [
+                                        [
+                                            'revid' => 1
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                        ]),
+                        'that.wikibase.cloud' => Http::response([
+                        'query' => [
+                            'allrevisions' => [
+                                [
+                                    'revisions' => [
+                                        [
+                                            'revid' => 1
+                                        ]
+                                    ]
+                                ]
+                            ]
+                        ]
+                    ]),
+                ],
                 getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&format=json&prop=revisions&rvprop=timestamp&formatversion=2&revids=2' => [
                     'this.wikibase.cloud' => Http::response([
                         'query' => [
@@ -121,56 +150,29 @@ class UpdateWikiSiteStatsJobTest extends TestCase
                         ]
                     ]),
                 ],
-                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&list=recentchanges&format=json&rcexcludeuser=PlatformReservedUser' => [
+                getenv('PLATFORM_MW_BACKEND_HOST').'/w/api.php?action=query&format=json&prop=revisions&rvprop=timestamp&formatversion=2&revids=1' => [
                     'this.wikibase.cloud' => Http::response([
                         'query' => [
-                            'recentchanges' => [
+                            'pages' => [
                                 [
-                                    'type' => 'new',
-                                    'ns' => 120,
-                                    'title' => 'Item:Q312951',
-                                    'pageid' => 310675,
-                                    'revid' => 830699,
-                                    'old_revid' => 0,
-                                    'rcid' => 829604,
-                                    'timestamp' => '2023-09-16T17:22:33Z'
-                                ],
-                                [
-
-                                    'type' => 'edit',
-                                    'ns' => 4,
-                                    'title' => 'Project:Home',
-                                    'pageid' => 1,
-                                    'revid' => 830698,
-                                    'old_revid' => 830094,
-                                    'rcid' => 829603,
-                                    'timestamp' => '2023-09-16T04:50:03Z'
+                                    'revisions' => [
+                                        [
+                                            'timestamp' => '2023-09-16T17:22:33Z'
+                                        ]
+                                    ]
                                 ]
                             ]
                         ]
                     ]),
                     'that.wikibase.cloud' => Http::response([
                         'query' => [
-                            'recentchanges' => [
+                            'pages' => [
                                 [
-                                    'type' => 'edit',
-                                    'ns' => 120,
-                                    'title' => 'Item:Q158700',
-                                    'pageid' => 204252,
-                                    'revid' => 438675,
-                                    'old_revid' => 438674,
-                                    'rcid' => 441539,
-                                    'timestamp' => '2023-09-19T11:35:09Z'
-                                ],
-                                [
-                                    'type' => 'edit',
-                                    'ns' => 120,
-                                    'title' => 'Item:Q158700',
-                                    'pageid' => 204252,
-                                    'revid' => 438674,
-                                    'old_revid' => 438673,
-                                    'rcid' => 441538,
-                                    'timestamp' => '2023-09-19T11:33:50Z'
+                                    'revisions' => [
+                                        [
+                                            'timestamp' => '2023-09-19T11:35:09Z'
+                                        ]
+                                    ]
                                 ]
                             ]
                         ]


### PR DESCRIPTION
This commit calculates the last edited time using a similar methodology to the existing on to calculated first edited time. It uses the `allrevisions` list.

This method will exclude all revisions created by the PlatformReservedUser. This means that it will erroneously ignore revisions from importing entities.

Bug: T364991