### PR TITLE
fix(entity-import): pass validated input to payload field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,12 @@
 # api
 
-## 10.11.0 - 31 July 2024
+## 10x.11.1 - 1 August 2024
+- Fix null `payload` field in WikiEntityImport records
+
+## 10x.11.0 - 31 July 2024
 - Bump transferbot image, allow revisioned entity ids in validation
 
-## 10.10.0 - 30 July 2024
+## 10x.10.0 - 30 July 2024
 - Add Backend for Entity Import Feature T360031
 
 ## 10x.9.1 - 23 July 2024

--- a/app/Http/Controllers/WikiEntityImportController.php
+++ b/app/Http/Controllers/WikiEntityImportController.php
@@ -63,7 +63,7 @@ class WikiEntityImportController extends Controller
         $import = $wiki->wikiEntityImports()->create([
             'status' => WikiEntityImportStatus::Pending,
             'started_at' => Carbon::now(),
-            'payload' => $request->all(),
+            'payload' => $validatedInput,
         ]);
 
         dispatch(new WikiEntityImportJob(


### PR DESCRIPTION
I noticed the `payload` of a WikiEntityImport model (which is saved for debugging purposes) will currently end up as `null`:

```
      App\WikiEntityImport {#6869                                                                                                                                                                           
        +id: 1,
        +created_at: "2024-07-31 11:56:59",
        +updated_at: "2024-07-31 11:57:43",
        +wiki_id: 413,
        status: "success",
        started_at: "2024-07-31 11:56:59",
        finished_at: "2024-07-31 11:57:43",
        +payload: null,
      },
``` 