### PR TITLE
fix: compose is a docker plugin now

### DIFF
--- a/.github/workflows/composer.test.yml
+++ b/.github/workflows/composer.test.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Run docker-compose setup
       env:
         DATABASE_IMAGE_NAME: ${{ matrix.databaseImageName }}
-      run: docker-compose -f docker-compose.yml -f docker-compose.integration.yml up -d
+      run: docker compose -f docker-compose.yml -f docker-compose.integration.yml up -d
 
     - name: Setup - Keep trying to install the DBs (try for 30 seconds)
       uses: nick-invision/retry@v3.0.0
@@ -40,18 +40,18 @@ jobs:
         max_attempts: 30
         retry_wait_seconds: 1
         timeout_seconds: 30
-        command: docker-compose exec -T api php artisan migrate:fresh
+        command: docker compose exec -T api php artisan migrate:fresh
 
     - name: Setup - Other things
       run: |
-        docker-compose exec -T api php artisan key:generate
+        docker compose exec -T api php artisan key:generate
 
     - name: PHPUnit
-      run: docker-compose exec -e APP_ENV=testing -T api vendor/bin/phpunit
+      run: docker compose exec -e APP_ENV=testing -T api vendor/bin/phpunit
     - name: Psalm
-      run: docker-compose exec -T api vendor/bin/psalm
+      run: docker compose exec -T api vendor/bin/psalm
 
     - name: Run elasticsearch index deletion integration test
-      run: docker-compose exec -e RUN_PHPUNIT_INTEGRATION_TEST=1 -e ELASTICSEARCH_HOST=elasticsearch.svc:9200 -T api vendor/bin/phpunit tests/Jobs/Integration/ElasticSearchIndexDeleteTest.php
+      run: docker compose exec -e RUN_PHPUNIT_INTEGRATION_TEST=1 -e ELASTICSEARCH_HOST=elasticsearch.svc:9200 -T api vendor/bin/phpunit tests/Jobs/Integration/ElasticSearchIndexDeleteTest.php
     - name: Run blazegraph integration test
-      run: docker-compose exec -e RUN_PHPUNIT_INTEGRATION_TEST=1 -T api vendor/bin/phpunit tests/Jobs/Integration/QueryserviceNamespaceJobTest.php
+      run: docker compose exec -e RUN_PHPUNIT_INTEGRATION_TEST=1 -T api vendor/bin/phpunit tests/Jobs/Integration/QueryserviceNamespaceJobTest.php


### PR DESCRIPTION
Starting today, tests started failing with

```
/home/runner/work/_temp/b56fec0a-4ac0-48be-9695-939a2d709bb9.sh: line 1: docker-compose: command not found
```

which apparently means compose v1 was now dropped from the runners.