### PR TITLE
chore: silence curl output for entity import callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # api
 
+## 10x.14.1 - 13 August 2024
+- Silence curl output for entity import callbacks
+
 ## 10x.14.0 - 12 August 2024
 - Add Prometheus metrics regarding Entity Import feature
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # api
 
-## 10x.14.1 - 13 August 2024
+## 10x.14.1 - 14 August 2024
 - Silence curl output for entity import callbacks
+- Make payload field in entity import fillable
 
 ## 10x.14.0 - 12 August 2024
 - Add Prometheus metrics regarding Entity Import feature

--- a/app/Jobs/WikiEntityImportJob.php
+++ b/app/Jobs/WikiEntityImportJob.php
@@ -172,11 +172,11 @@ class TransferBotKubernetesJob
                                     ...$this->creds->marshalEnv(),
                                     [
                                         'name' => 'CALLBACK_ON_FAILURE',
-                                        'value' => 'curl -H "Accept: application/json" -H "Content-Type: application/json" --data \'{"wiki_entity_import":'.$this->importId.',"status":"failed"}\' -XPATCH http://api-app-backend.default.svc.cluster.local/backend/wiki/updateEntityImport'
+                                        'value' => 'curl -sS -H "Accept: application/json" -H "Content-Type: application/json" --data \'{"wiki_entity_import":'.$this->importId.',"status":"failed"}\' -XPATCH http://api-app-backend.default.svc.cluster.local/backend/wiki/updateEntityImport'
                                     ],
                                     [
                                         'name' => 'CALLBACK_ON_SUCCESS',
-                                        'value' => 'curl -H "Accept: application/json" -H "Content-Type: application/json" --data \'{"wiki_entity_import":'.$this->importId.',"status":"success"}\' -XPATCH http://api-app-backend.default.svc.cluster.local/backend/wiki/updateEntityImport'
+                                        'value' => 'curl -sS -H "Accept: application/json" -H "Content-Type: application/json" --data \'{"wiki_entity_import":'.$this->importId.',"status":"success"}\' -XPATCH http://api-app-backend.default.svc.cluster.local/backend/wiki/updateEntityImport'
                                     ],
                                 ],
                                 'command' => [


### PR DESCRIPTION
As discussed yesterday, this removes some noise from the logs.