### PR TITLE
fix(entity-import): payload field is not fillable

### DIFF
--- a/app/WikiEntityImport.php
+++ b/app/WikiEntityImport.php
@@ -12,6 +12,7 @@ class WikiEntityImport extends Model
         'status',
         'started_at',
         'finished_at',
+        'payload',
     ];
 
     protected $fillable = self::FIELDS;
@@ -20,5 +21,6 @@ class WikiEntityImport extends Model
 
     protected $casts = [
         'status' => WikiEntityImportStatus::class,
+        'payload' => 'array',
     ];
 }


### PR DESCRIPTION
Even after #855 `payload` would still be `null` as the field is not fillable yet.