### PR TITLE
add new skins to possible values

### DIFF
--- a/app/Http/Controllers/WikiSettingController.php
+++ b/app/Http/Controllers/WikiSettingController.php
@@ -19,7 +19,7 @@ class WikiSettingController extends Controller
     {
         // FIXME: this list is evil and should be kept in sync with the model in Wiki.php?! (mostly)
         return [
-            'wgDefaultSkin' => ['required', 'string', 'in:vector,modern,timeless'],
+            'wgDefaultSkin' => ['required', 'string', 'in:vector,modern,timeless,minerva,vector-2022'],
             'wwExtEnableConfirmAccount' => ['required', 'boolean'],
             'wwExtEnableWikibaseLexeme' => ['required', 'boolean'],
             'wwWikibaseStringLengthString' => ['required', 'integer', 'between:400,2500'],


### PR DESCRIPTION
https://phabricator.wikimedia.org/T375546

adds `minerva` and `vector-2022` as possible valid values for `wgDefaultSkin`

sibling of https://github.com/wbstack/ui/pull/894