### PR TITLE
Test create wiki api endpoint can accept a profile

### DIFF
--- a/tests/Routes/Wiki/CreateTest.php
+++ b/tests/Routes/Wiki/CreateTest.php
@@ -51,15 +51,7 @@ class CreateTest extends TestCase
         Config::set( 'wbstack.elasticsearch_shared_index_host', $sharedIndexHost );
         Config::set( 'wbstack.elasticsearch_shared_index_prefix', $sharedIndexPrefix );
 
-        // seed up ready db
-        $manager = $this->app->make('db');
-        $job = new ProvisionWikiDbJob();
-        $job->handle($manager);
-
-        $dbRow = QueryserviceNamespace::create([
-            'namespace' => "derp",
-            'backend' => "wdqs.svc",
-        ]);
+        $this->createSQLandQSDBs();
 
         Queue::fake();
 
@@ -236,10 +228,22 @@ class CreateTest extends TestCase
             ->assertJsonPath('success', true );
     }
 
+    private function createSQLandQSDBs(): void {
+        $manager = $this->app->make('db');
+        $job = new ProvisionWikiDbJob();
+        $job->handle($manager);
+
+        QueryserviceNamespace::create([
+            'namespace' => "derp",
+            'backend' => "wdqs.svc",
+        ]);
+    }
+
     /**
      * @dataProvider createWikiHandlesRangeOfPostValuesProvider
      */
     public function testCreateWikiHandlesRangeOfPostValues($data, $expectedStatus): void {
+        $this->createSQLandQSDBs();
         Queue::fake();
         $user = User::factory()->create(['verified' => true]);
         $response = $this->actingAs($user, 'api')


### PR DESCRIPTION
This commit asserts that adding the additional profile parameter to the wiki creation API does not result in failure.

The purpose of this is to make clear that UI development can go ahead and add this parameter to requests without it being necessary to have completed the api work first.

Note that the PR does not make this parameter required; otherwise we would be unable to deploy this change without also concurrently deploying a UI update that always sends this parameter

It also adds assertions for the parameters that are required for the wiki creation api

Bug: T388640