### PR TITLE
Remove version from docker-compose files

### DIFF
--- a/database/mw/docker-compose-clean.yml
+++ b/database/mw/docker-compose-clean.yml
@@ -1,5 +1,3 @@
-version: '3.1'
-
 services:
 
   mediawiki:

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   wdqs:
     image: ghcr.io/wbstack/queryservice:0.3.6_0.6

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '2'
 services:
   api:
     build:


### PR DESCRIPTION
This is now not needed in compose files since compose V2[0]

[0] https://docs.docker.com/compose/releases/migrate/