### PR TITLE
introduce WikiProfile model and test

### DIFF
--- a/app/WikiProfile.php
+++ b/app/WikiProfile.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App;
+
+use App\Wiki;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class WikiProfile extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'wiki_id',
+        'purpose',
+        'purpose_other',
+        'audience',
+        'audience_other',
+        'temporality',
+        'temporality_other',
+    ];
+
+    public function wiki(): BelongsTo
+    {
+        return $this->belongsTo(Wiki::class);
+    }
+
+}

--- a/database/migrations/2025_03_14_220054_create_wiki_profiles_table.php
+++ b/database/migrations/2025_03_14_220054_create_wiki_profiles_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('wiki_profiles', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('wiki_id');
+            $table->foreign('wiki_id')->references('id')->on('wikis');
+            $table->enum('purpose', ['data_hub', 'data_lab', 'tool_lab', 'test_drive', 'decide_later', 'other']);
+            $table->string('purpose_other')->nullable();
+            $table->enum('audience', ['narrow', 'wide', 'other']);
+            $table->string('audience_other')->nullable();
+            $table->enum('temporality', ['permanent', 'temporary', 'decide_later', 'other']);
+            $table->string('temporality_other')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('wiki_profiles');
+    }
+};

--- a/tests/WikiProfileTest.php
+++ b/tests/WikiProfileTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Tests;
+
+use App\Wiki;
+use App\WikiProfile;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class WikiProfileTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected Wiki $wiki;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->wiki = Wiki::factory()->create();
+    }
+    
+    public function testCreateValidWikiProfile(): void
+    {
+        $profile = new WikiProfile([
+            'wiki_id' => $this->wiki->id,
+            'purpose' => 'data_hub',
+            'audience' => 'narrow',
+            'temporality' => 'permanent',
+        ]);
+
+        $profile->save();
+
+        $this->assertDatabaseHas('wiki_profiles', [
+            'wiki_id' => $this->wiki->id,
+            'purpose' => 'data_hub',
+            'audience' => 'narrow',
+            'temporality' => 'permanent',
+        ]);
+    }
+
+    public function testCreateWikiProfileWithOtherFields(): void
+    {
+        $profile = new WikiProfile([
+            'wiki_id' => $this->wiki->id,
+            'purpose' => 'other',
+            'purpose_other' => 'Custom purpose',
+            'audience' => 'other',
+            'audience_other' => 'Custom audience',
+            'temporality' => 'other',
+            'temporality_other' => 'Custom temporality',
+        ]);
+
+        $profile->save();
+
+        $this->assertDatabaseHas('wiki_profiles', [
+            'wiki_id' => $this->wiki->id,
+            'purpose' => 'other',
+            'purpose_other' => 'Custom purpose',
+            'audience' => 'other',
+            'audience_other' => 'Custom audience',
+            'temporality' => 'other',
+            'temporality_other' => 'Custom temporality',
+        ]);
+    }
+
+}


### PR DESCRIPTION
This commit introduces a basic wiki profile model, the migration
to save the data in the database and a very simple test to confirm
that it works.

I thought for a while about including a load of validation here
e.g. Other values have some string for the other details
but I decided that this should probably live just in a validator
that's used at the controller level.

I also decided that we would allow multiple profiles per wiki.
We'll need to just reference the newest one when showing them
to users but this will allow us to monitor the changes in profiles
over time.

Bug: T388895