### PR TITLE
Create WikiProfile objects when a Wiki is made

### DIFF
--- a/app/Helper/ProfileValidator.php
+++ b/app/Helper/ProfileValidator.php
@@ -1,0 +1,21 @@
+<?php
+namespace App\Helper;
+
+use Illuminate\Support\Facades\Validator;
+use App\Http\Controllers\WikiController;
+
+class ProfileValidator 
+{
+    public function validate( $profile ): \Illuminate\Validation\Validator {
+
+        return Validator::make($profile, [
+            'purpose' => 'in:data_hub,data_lab,tool_lab,test_drive,decide_later,other',
+            'purpose_other' => 'string|required_if:purpose,other|missing_unless:purpose,other',
+            'audience' => 'in:narrow,wide,other',
+            'audience_other' => 'string|required_if:audience,other|missing_unless:audience,other',
+            'temporality' => 'in:permanent,temporary,decide_later,other',
+            'temporality_other' => 'string|required_if:temporality,other|missing_unless:temporality,other',
+        ]);
+    }
+
+}

--- a/tests/Helper/ProfileValidatorTest.php
+++ b/tests/Helper/ProfileValidatorTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace Tests\Jobs;
+
+use Tests\TestCase;
+use App\Helper\ProfileValidator;
+
+class ProfileValidatorTest extends TestCase {
+   
+    /**
+     * @dataProvider validProfileProvider
+     */
+    public function testProfileValidatorWorksWithValidProfile($profile): void {
+        $validatorFactory = new ProfileValidator();
+        $validator=$validatorFactory->validate($profile);
+        $this->assertTrue($validator->passes());
+    }
+
+    /**
+     * @dataProvider invalidProfileProvider
+     */
+    public function testProfileValidatorWorksWithInvalidProfile($profile): void {
+        $validatorFactory = new ProfileValidator();
+        $validator=$validatorFactory->validate($profile);
+        $this->assertFalse($validator->passes());
+    }
+
+    private function validProfileProvider() {
+        return [
+            [ 'boring profile with no other' => [
+                'purpose' => 'data_hub',
+                'audience' => 'narrow',
+                'temporality' => 'permanent',
+            ] ],
+            [ 'with other values' => [
+                'purpose' => 'other',
+                'purpose_other' => 'for fun',
+                'audience' => 'other',
+                'audience_other' => 'my cat',
+                'temporality' => 'other',
+                'temporality_other' => 'only in the past',
+            ] ],
+        ];
+    }
+
+
+    private function invalidProfileProvider() {
+        return [
+            [ 'missing other keys' => [
+                'purpose' => 'other',
+                'audience' => 'narrow',
+                'temporality' => 'permanent',
+            ] ],
+            [ 'other keys when there should not be' => [
+                'purpose' => 'data_hub',
+                'purpose_other' => 'asdfasdf',
+                'audience' => 'narrow',
+                'temporality' => 'permanent',
+            ] ],
+        ];
+    }
+}


### PR DESCRIPTION
This creates a WikiProfile object if a profile is provided
at wiki creation time.

It also add some validation for the form of this profile
over the network.

It should be noted that the _other strings are stored
unsantised user input. We need to take this into account
if we do anything with them

Bug: T389063