### PR TITLE
bug: fix WikiProfile audience not nullable

### DIFF
--- a/database/migrations/2025_03_25_085142_wiki_profiles_audience_nullable.php
+++ b/database/migrations/2025_03_25_085142_wiki_profiles_audience_nullable.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+            DB::statement('
+                ALTER TABLE `wiki_profiles` CHANGE COLUMN `audience` `audience` 
+                ENUM("narrow", "wide", "other")
+            ');
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        //  n.b. this rollback won't work if there are null audience values in the db
+            DB::statement('
+                ALTER TABLE `wiki_profiles` CHANGE COLUMN `audience` `audience`
+                ENUM("narrow", "wide", "other")
+                NOT NULL
+            ');
+
+    }
+};


### PR DESCRIPTION
WikiProfile audiences should be nullable but aren't I was unable to make them nullable using the laravel ORM

This migration does it using raw SQL following this issue [0] in the laravel bug tracker

[0] https://github.com/laravel/framework/issues/35096#issuecomment-1512754452