### PR TITLE
WikiDailyMetrics: add comparison method

### DIFF
--- a/app/Metrics/App/WikiMetrics.php
+++ b/app/Metrics/App/WikiMetrics.php
@@ -7,32 +7,37 @@ use App\WikiDailyMetrics;
 
 class WikiMetrics
 {
-
     public function saveMetrics(Wiki $wiki): void
     {
         $today = now()->format('Y-m-d');
         $oldRecord = WikiDailyMetrics::where('wiki_id', $wiki->id)->latest('date')->first();
         $todayPageCount = $wiki->wikiSiteStats()->first()->pages ?? 0;
         $isDeleted = (bool)$wiki->deleted_at;
+
+        $dailyMetrics = new WikiDailyMetrics([
+            'id' => $wiki->id . '_' . date('Y-m-d'),
+            'pages' => $todayPageCount,
+            'is_deleted' => $isDeleted,
+            'date' => $today,
+            'wiki_id' => $wiki->id
+        ]);
+        
         if ($oldRecord) {
             if ($oldRecord->is_deleted) {
                 \Log::info("Wiki is deleted, no new record for WikiMetrics ID {$wiki->id}.");
                 return;
             }
+
             if (!$isDeleted) {
-                if ($oldRecord->pages === $todayPageCount) {
-                    \Log::info("Page count unchanged for WikiMetrics ID {$wiki->id}, no new record added.");
+                if ($oldRecord->areMetricsEqual($dailyMetrics)) {
+                    \Log::info("Record unchanged for WikiMetrics ID {$wiki->id}, no new record added.");
                     return;
                 }
             }
         }
-        WikiDailyMetrics::create([
-            'id' => $wiki->id . '_' . date('Y-m-d'),
-            'pages' => $todayPageCount,
-            'is_deleted' => $isDeleted,
-            'date' => $today,
-            'wiki_id' => $wiki->id,
-        ]);
+
+        $dailyMetrics->save();
+
         \Log::info("New metric recorded for WikiMetrics ID {$wiki->id}");
     }
 

--- a/app/Metrics/App/WikiMetrics.php
+++ b/app/Metrics/App/WikiMetrics.php
@@ -40,6 +40,4 @@ class WikiMetrics
 
         \Log::info("New metric recorded for WikiMetrics ID {$wiki->id}");
     }
-
 }
-

--- a/app/WikiDailyMetrics.php
+++ b/app/WikiDailyMetrics.php
@@ -25,5 +25,19 @@ class WikiDailyMetrics extends Model
         'is_deleted',
     ];
 
+    // list of properties which are actual wiki metrics
+    static public $metricNames = [
+        'pages',
+        'is_deleted',
+    ];
 
+    public function areMetricsEqual(WikiDailyMetrics $wikiDailyMetrics) {
+
+        foreach(self::$metricNames as $field) {
+            if ($this->$field !== $wikiDailyMetrics->$field) {
+                return false;
+            }
+        }
+        return true;
+    }
 }

--- a/app/WikiDailyMetrics.php
+++ b/app/WikiDailyMetrics.php
@@ -26,18 +26,19 @@ class WikiDailyMetrics extends Model
     ];
 
     // list of properties which are actual wiki metrics
-    static public $metricNames = [
+    public static $metricNames = [
         'pages',
         'is_deleted',
     ];
 
-    public function areMetricsEqual(WikiDailyMetrics $wikiDailyMetrics) {
-
+    public function areMetricsEqual(WikiDailyMetrics $wikiDailyMetrics): bool
+    {
         foreach(self::$metricNames as $field) {
-            if ($this->$field !== $wikiDailyMetrics->$field) {
+            if ($this->$field != $wikiDailyMetrics->$field) {
                 return false;
             }
         }
+
         return true;
     }
 }

--- a/tests/WikiDailyMetricsTest.php
+++ b/tests/WikiDailyMetricsTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Tests;
+
+use Tests\TestCase;
+use App\WikiDailyMetrics;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class WikiDailyMetricsTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public static function areMetricsEqualProvider(){
+        yield 'is the same' => [
+            new WikiDailyMetrics(["pages" => 1, "is_deleted" => false ]),
+            new WikiDailyMetrics(["pages" => 1, "is_deleted" => false ]),
+            true
+        ];
+
+        yield 'more pages' => [
+            new WikiDailyMetrics(["pages" => 1, "is_deleted" => false ]),
+            new WikiDailyMetrics(["pages" => 20, "is_deleted" => false ]),
+            false
+        ];
+
+        yield 'less pages' => [
+            new WikiDailyMetrics(["pages" => 10, "is_deleted" => false ]),
+            new WikiDailyMetrics(["pages" => 1, "is_deleted" => false ]),
+            false
+        ];
+
+        yield 'is deleted' => [
+            new WikiDailyMetrics(["pages" => 1, "is_deleted" => false ]),
+            new WikiDailyMetrics(["pages" => 1, "is_deleted" => true ]),
+            false
+        ];
+    }
+
+    /**
+     * @dataProvider areMetricsEqualProvider
+     */
+    public function testAreMetricsEqual(
+        WikiDailyMetrics $wikiDailyMetrics1,
+        WikiDailyMetrics $wikiDailyMetrics2,
+        $assertion
+    ): void
+    {
+        $this->assertEquals(
+            $wikiDailyMetrics1->areMetricsEqual($wikiDailyMetrics2),
+            $assertion
+        );
+    }
+}


### PR DESCRIPTION
https://phabricator.wikimedia.org/T383427
https://phabricator.wikimedia.org/T391386

In order to more easily compare wiki metric objects we added a comparison method, which will get extended with further metrics properties
