### PR TITLE
Add handling of content reports

### DIFF
--- a/app/ComplaintRecord.php
+++ b/app/ComplaintRecord.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * App\ComplaintRecord.
+ *
+ * @property int $id
+ * @property string|null $name
+ * @property string|null $mail_address
+ * @property string $reason
+ * @property string $offending_urls
+ * @property \Illuminate\Support\Carbon|null $dispatched_at
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @mixin \Eloquent
+ */
+class ComplaintRecord extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'mail_address',
+        'reason',
+        'offending_urls',
+    ];
+
+    public function markAsDispatched()
+    {
+        $this->dispatched_at = Carbon::now();
+    }
+}

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -10,6 +10,7 @@ use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Notification;
 use Illuminate\Validation\Rule;
 use App\ComplaintRecord;
+use Illuminate\Support\Facades\Log;
 
 class ComplaintController extends Controller
 {
@@ -98,7 +99,7 @@ class ComplaintController extends Controller
                 'nullable',
                 'max:300',
                 Rule::when(
-                    !empty($data['mailAddress']),
+                    !empty($data['email']),
                     ['email:rfc']
                 ),
             ],

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -87,7 +87,7 @@ class ComplaintController extends Controller
                 'nullable',
                 'max:300',
                 Rule::when(
-                    !empty($mailAddress), 
+                    !empty($data['mailAddress']),
                     ['email:rfc']
                 ),
             ],

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Notifications\ComplaintNotification;
+use App\Rules\ReCaptchaValidation;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Validation\Rule;
+
+class ComplaintController extends Controller
+{
+    /**
+     * @var \App\Rules\ReCaptchaValidation
+     */
+    protected $recaptchaValidation;
+
+    public function __construct(ReCaptchaValidation $recaptchaValidation) {
+        $this->recaptchaValidation = $recaptchaValidation;
+    }
+
+    /**
+     * Handle a complaint report page request for the application.
+     *
+     * @param \Illuminate\Http\Request  $request
+     */
+    public function sendMessage(Request $request): \Illuminate\Http\JsonResponse
+    {
+        $validator = $this->validator($request->all());
+
+        if ($validator->fails()) {
+            $failed = $validator->failed();
+
+            if (isset($failed['recaptcha'])) {
+                abort(401);
+            } else {
+                abort(400);
+            }
+        }
+
+        $validated = $validator->safe();
+
+        Notification::route('mail', [
+            config('app.complaint-mail-recipient'),
+        ])->notify(
+            new ComplaintNotification(
+                $validated['offendingUrls'],
+                $validated['reason'],
+                $validated['name'],
+                $validated['mailAddress'],
+            )
+        );
+
+        return response()->json('Success', 200);
+    }
+
+    /**
+     * Get a validator for an incoming complaint report page request.
+     */
+    protected function validator(array $data): \Illuminate\Validation\Validator
+    {
+        if (! isset($data['name'])) {
+            $data['name'] = '';
+        }
+
+        if (! isset($data['mailAddress'])) {
+            $data['mailAddress'] = '';
+        }
+
+        $validation = [
+            'recaptcha'      => ['required', 'string', 'bail', $this->recaptchaValidation],
+            'name'           => ['nullable', 'string', 'max:300'],
+            'reason'         => ['required', 'string', 'max:10000'],
+            'offendingUrls'  => ['required', 'string', 'max:10000'],
+
+            'mailAddress'    => [
+                'nullable',
+                'max:300',
+                Rule::when(
+                    !empty($mailAddress), 
+                    ['email:rfc,dns']
+                ),
+            ],
+        ];
+
+        return Validator::make($data, $validation);
+    }
+}

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -91,8 +91,8 @@ class ComplaintController extends Controller
         $validation = [
             'recaptcha'      => ['required', 'string', 'bail', $this->recaptchaValidation],
             'name'           => ['nullable', 'string', 'max:300'],
-            'message'        => ['required', 'string', 'max:10000'],
-            'url'            => ['required', 'string', 'max:10000'],
+            'message'        => ['required', 'string', 'max:1000'],
+            'url'            => ['required', 'string', 'max:1000'],
 
             'email'    => [
                 'nullable',

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -74,13 +74,8 @@ class ComplaintController extends Controller
      */
     protected function validator(array $data): \Illuminate\Validation\Validator
     {
-        if (! isset($data['name'])) {
-            $data['name'] = '';
-        }
-
-        if (! isset($data['mailAddress'])) {
-            $data['mailAddress'] = '';
-        }
+        $data['name'] = $data['name'] ?? '';
+        $data['mailAddress'] = $data['mailAddress'] ?? '';
 
         $validation = [
             'recaptcha'      => ['required', 'string', 'bail', $this->recaptchaValidation],

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -43,16 +43,18 @@ class ComplaintController extends Controller
         $validated = $validator->safe();
 
         if (! empty($validated['mailAddress'])) {
-            Notification::route('mail', [
-                $validated['mailAddress'],
-            ])->notify(
-                new ComplaintNotificationExternal(
+            $internalNotification = new ComplaintNotificationExternal(
                     $validated['offendingUrls'],
                     $validated['reason'],
                     $validated['name'],
                     $validated['mailAddress'],
-                )
             );
+
+            Notification::route('mail', [
+                $validated['mailAddress'],
+            ])->notify($internalNotification);
+
+            Notification::route('database', $validated['mailAddress'])->notify($internalNotification);
         }
 
         Notification::route('mail', [

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Notifications\ExternalComplaintNotification;
 use App\Notifications\ComplaintNotification;
 use App\Rules\ReCaptchaValidation;
 use Illuminate\Http\Request;
@@ -51,6 +52,19 @@ class ComplaintController extends Controller
                 $validated['mailAddress'],
             )
         );
+
+        if (! empty($validated['mailAddress'])) {
+            Notification::route('mail', [
+                $validated['mailAddress'],
+            ])->notify(
+                new ExternalComplaintNotification(
+                    $validated['offendingUrls'],
+                    $validated['reason'],
+                    $validated['name'],
+                    $validated['mailAddress'],
+                )
+            );
+        }
 
         return response()->json('Success', 200);
     }

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -88,7 +88,7 @@ class ComplaintController extends Controller
                 'max:300',
                 Rule::when(
                     !empty($mailAddress), 
-                    ['email:rfc,dns']
+                    ['email:rfc']
                 ),
             ],
         ];

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -45,14 +45,14 @@ class ComplaintController extends Controller
 
         $complaintRecord = new ComplaintRecord;
         $complaintRecord->name = $validated['name'];
-        $complaintRecord->mail_address = $validated['mailAddress'];
-        $complaintRecord->reason = $validated['reason'];
-        $complaintRecord->offending_urls = $validated['offendingUrls'];
+        $complaintRecord->mail_address = $validated['email'];
+        $complaintRecord->reason = $validated['message'];
+        $complaintRecord->offending_urls = $validated['url'];
         $complaintRecord->save();
 
-        if (! empty($validated['mailAddress'])) {
+        if (! empty($complaintRecord->mail_address)) {
             Notification::route('mail', [
-                $validated['mailAddress'],
+               $complaintRecord->mail_address,
             ])->notify(
                 new ComplaintNotificationExternal(
                     $complaintRecord->offending_urls,
@@ -86,15 +86,15 @@ class ComplaintController extends Controller
     protected function validator(array $data): \Illuminate\Validation\Validator
     {
         $data['name'] = $data['name'] ?? '';
-        $data['mailAddress'] = $data['mailAddress'] ?? '';
+        $data['email'] = $data['email'] ?? '';
 
         $validation = [
             'recaptcha'      => ['required', 'string', 'bail', $this->recaptchaValidation],
             'name'           => ['nullable', 'string', 'max:300'],
-            'reason'         => ['required', 'string', 'max:10000'],
-            'offendingUrls'  => ['required', 'string', 'max:10000'],
+            'message'        => ['required', 'string', 'max:10000'],
+            'url'            => ['required', 'string', 'max:10000'],
 
-            'mailAddress'    => [
+            'email'    => [
                 'nullable',
                 'max:300',
                 Rule::when(

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Notifications\ExternalComplaintNotification;
+use App\Notifications\ComplaintNotificationExternal;
 use App\Notifications\ComplaintNotification;
 use App\Rules\ReCaptchaValidation;
 use Illuminate\Http\Request;
@@ -46,7 +46,7 @@ class ComplaintController extends Controller
             Notification::route('mail', [
                 $validated['mailAddress'],
             ])->notify(
-                new ExternalComplaintNotification(
+                new ComplaintNotificationExternal(
                     $validated['offendingUrls'],
                     $validated['reason'],
                     $validated['name'],

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -42,17 +42,6 @@ class ComplaintController extends Controller
 
         $validated = $validator->safe();
 
-        Notification::route('mail', [
-            config('app.complaint-mail-recipient'),
-        ])->notify(
-            new ComplaintNotification(
-                $validated['offendingUrls'],
-                $validated['reason'],
-                $validated['name'],
-                $validated['mailAddress'],
-            )
-        );
-
         if (! empty($validated['mailAddress'])) {
             Notification::route('mail', [
                 $validated['mailAddress'],
@@ -65,6 +54,17 @@ class ComplaintController extends Controller
                 )
             );
         }
+
+        Notification::route('mail', [
+            config('app.complaint-mail-recipient'),
+        ])->notify(
+            new ComplaintNotification(
+                $validated['offendingUrls'],
+                $validated['reason'],
+                $validated['name'],
+                $validated['mailAddress'],
+            )
+        );
 
         return response()->json('Success', 200);
     }

--- a/app/Notifications/ComplaintNotification.php
+++ b/app/Notifications/ComplaintNotification.php
@@ -25,7 +25,7 @@ class ComplaintNotification extends Notification
      * @param  string  $mailAddress
      * @return void
      */
-    public function __construct($offendingUrls, $reason, $name='None', $mailAddress='None')
+    public function __construct($offendingUrls, $reason, $name=null, $mailAddress=null)
     {
         $this->offendingUrls = $offendingUrls;
         $this->reason = $reason;
@@ -52,6 +52,17 @@ class ComplaintNotification extends Notification
      */
     public function toMail($notifiable)
     {
+        $name = $this->name;
+        $mailAddress = $this->mailAddress;
+
+        if (empty($name)) {
+            $name = 'None';
+        }
+
+        if (empty($mailAddress)) {
+            $mailAddress = 'None';
+        }
+
         $mailFrom = config('app.complaint-mail-sender');
         $mailSubject = config('app.name') . ': Report of Illegal Content';
 
@@ -59,11 +70,10 @@ class ComplaintNotification extends Notification
             ->from($mailFrom)
             ->subject($mailSubject)
             ->line(Lang::get('A message via the wikibase.cloud form for reporting illegal content has been submitted.'))
-            ->line(Lang::get('Reporter name: ') . $this->name)
-            ->line(Lang::get('Reporter email address: ') . $this->mailAddress)
+            ->line(Lang::get('Reporter name: ') . $name)
+            ->line(Lang::get('Reporter email address: ') . $mailAddress)
             ->line(Lang::get('Reason why the information in question is illegal content:'))
             ->line($this->reason)
-            ->line('---')
             ->line(Lang::get('URL(s) for the content in question:'))
             ->line($this->offendingUrls)
             ->line('---');

--- a/app/Notifications/ComplaintNotification.php
+++ b/app/Notifications/ComplaintNotification.php
@@ -2,6 +2,7 @@
 
 namespace App\Notifications;
 
+use Illuminate\Notifications\Messages\DatabaseMessage;
 use Illuminate\Notifications\Messages\MailMessage;
 use Illuminate\Notifications\Notification;
 use Illuminate\Support\Facades\Lang;
@@ -77,5 +78,11 @@ class ComplaintNotification extends Notification
             ->line(Lang::get('URL(s) for the content in question:'))
             ->line($this->offendingUrls)
             ->line('---');
+    }
+
+    public function toDatabase($notifiable) {
+        $mail = $this->toMail($notifiable);
+
+        return (new DatabaseMessage($mail->toArray()));
     }
 }

--- a/app/Notifications/ComplaintNotification.php
+++ b/app/Notifications/ComplaintNotification.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+use Illuminate\Support\Facades\Lang;
+
+/**
+ * A notification to be sent when the legal complaint form is being used.
+ */
+class ComplaintNotification extends Notification
+{
+    public $textUrls;
+    public $textReason;
+    public $name;
+    public $mailAddress;
+
+    /**
+     * Create a notification instance.
+     *
+     * @param  string  $textUrls
+     * @param  string  $textReason
+     * @param  string  $name
+     * @param  string  $mailAddress
+     * @return void
+     */
+    public function __construct($textUrls, $textReason, $name='', $mailAddress='')
+    {
+        $this->textUrls = $textUrls;
+        $this->textReason = $textReason;
+        $this->name = $name;
+        $this->mailAddress = $mailAddress;
+    }
+
+    /**
+     * Get the notification's channels.
+     *
+     * @param  mixed  $notifiable
+     * @return array|string
+     */
+    public function via($notifiable)
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $mailAddress = $this->mailAddress ? $this->mailAddress:'None';
+        $name = $this->name ? $this->name:'None';
+
+        $mailFrom = config('app.complaint-mail-sender');
+        $mailSubject = config('app.name') . ': Report of Illegal Content';
+
+        return (new MailMessage)
+            ->from($mailFrom)
+            ->subject($mailSubject)
+            ->line(Lang::get('A message via the wikibase.cloud form for reporting illegal content has been submitted.'))
+            ->line(Lang::get('Reporter name: ') . $name)
+            ->line(Lang::get('Reporter email address: ') . $mailAddress)
+            ->line(Lang::get('Reason:'))
+            ->line($this->textReason)
+            ->line('---')
+            ->line(Lang::get('Reported URLs:'))
+            ->line($this->textUrls)
+            ->line('---');
+    }
+}

--- a/app/Notifications/ComplaintNotification.php
+++ b/app/Notifications/ComplaintNotification.php
@@ -11,24 +11,24 @@ use Illuminate\Support\Facades\Lang;
  */
 class ComplaintNotification extends Notification
 {
-    public $textUrls;
-    public $textReason;
+    public $offendingUrls;
+    public $reason;
     public $name;
     public $mailAddress;
 
     /**
      * Create a notification instance.
      *
-     * @param  string  $textUrls
-     * @param  string  $textReason
+     * @param  string  $offendingUrls
+     * @param  string  $reason
      * @param  string  $name
      * @param  string  $mailAddress
      * @return void
      */
-    public function __construct($textUrls, $textReason, $name='', $mailAddress='')
+    public function __construct($offendingUrls, $reason, $name='', $mailAddress='')
     {
-        $this->textUrls = $textUrls;
-        $this->textReason = $textReason;
+        $this->offendingUrls = $offendingUrls;
+        $this->reason = $reason;
         $this->name = $name;
         $this->mailAddress = $mailAddress;
     }
@@ -65,10 +65,10 @@ class ComplaintNotification extends Notification
             ->line(Lang::get('Reporter name: ') . $name)
             ->line(Lang::get('Reporter email address: ') . $mailAddress)
             ->line(Lang::get('Reason:'))
-            ->line($this->textReason)
+            ->line($this->reason)
             ->line('---')
             ->line(Lang::get('Reported URLs:'))
-            ->line($this->textUrls)
+            ->line($this->offendingUrls)
             ->line('---');
     }
 }

--- a/app/Notifications/ComplaintNotification.php
+++ b/app/Notifications/ComplaintNotification.php
@@ -41,7 +41,7 @@ class ComplaintNotification extends Notification
      */
     public function via($notifiable)
     {
-        return ['mail'];
+        return ['database', 'mail'];
     }
 
     /**

--- a/app/Notifications/ComplaintNotification.php
+++ b/app/Notifications/ComplaintNotification.php
@@ -25,7 +25,7 @@ class ComplaintNotification extends Notification
      * @param  string  $mailAddress
      * @return void
      */
-    public function __construct($offendingUrls, $reason, $name='', $mailAddress='')
+    public function __construct($offendingUrls, $reason, $name='None', $mailAddress='None')
     {
         $this->offendingUrls = $offendingUrls;
         $this->reason = $reason;
@@ -52,9 +52,6 @@ class ComplaintNotification extends Notification
      */
     public function toMail($notifiable)
     {
-        $mailAddress = $this->mailAddress ? $this->mailAddress:'None';
-        $name = $this->name ? $this->name:'None';
-
         $mailFrom = config('app.complaint-mail-sender');
         $mailSubject = config('app.name') . ': Report of Illegal Content';
 
@@ -62,12 +59,12 @@ class ComplaintNotification extends Notification
             ->from($mailFrom)
             ->subject($mailSubject)
             ->line(Lang::get('A message via the wikibase.cloud form for reporting illegal content has been submitted.'))
-            ->line(Lang::get('Reporter name: ') . $name)
-            ->line(Lang::get('Reporter email address: ') . $mailAddress)
-            ->line(Lang::get('Reason:'))
+            ->line(Lang::get('Reporter name: ') . $this->name)
+            ->line(Lang::get('Reporter email address: ') . $this->mailAddress)
+            ->line(Lang::get('Reason why the information in question is illegal content:'))
             ->line($this->reason)
             ->line('---')
-            ->line(Lang::get('Reported URLs:'))
+            ->line(Lang::get('URL(s) for the content in question:'))
             ->line($this->offendingUrls)
             ->line('---');
     }

--- a/app/Notifications/ComplaintNotificationExternal.php
+++ b/app/Notifications/ComplaintNotificationExternal.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Facades\Lang;
 /**
  * A notification to be sent when the legal complaint form is being used.
  */
-class ExternalComplaintNotification extends ComplaintNotification
+class ComplaintNotificationExternal extends ComplaintNotification
 {
     /**
      * Build the mail representation of the notification.

--- a/app/Notifications/ComplaintNotificationExternal.php
+++ b/app/Notifications/ComplaintNotificationExternal.php
@@ -32,12 +32,6 @@ class ComplaintNotificationExternal extends ComplaintNotification
             ->from($mailFrom)
             ->subject($mailSubject)
             ->line(Lang::get('Your message via the wikibase.cloud form for reporting illegal content has been submitted.'))
-            ->line(Lang::get('Name: ') . $name)
-            ->line(Lang::get('Email address: ') . $this->mailAddress)
-            ->line(Lang::get('Reason why the information in question is illegal content:'))
-            ->line($this->reason)
-            ->line(Lang::get('URL(s) for the content in question:'))
-            ->line($this->offendingUrls)
             ->line('---');
     }
 }

--- a/app/Notifications/ExternalComplaintNotification.php
+++ b/app/Notifications/ExternalComplaintNotification.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Notifications;
+
+use App\Notifications\ComplaintNotification;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Support\Facades\Lang;
+
+/**
+ * A notification to be sent when the legal complaint form is being used.
+ */
+class ExternalComplaintNotification extends ComplaintNotification
+{
+    /**
+     * Build the mail representation of the notification.
+     *
+     * @param  mixed  $notifiable
+     * @return \Illuminate\Notifications\Messages\MailMessage
+     */
+    public function toMail($notifiable)
+    {
+        $mailFrom = config('app.complaint-mail-sender');
+        $mailSubject = config('app.name') . ': Report of Illegal Content';
+
+        return (new MailMessage)
+            ->from($mailFrom)
+            ->subject($mailSubject)
+            ->line(Lang::get('Your message via the wikibase.cloud form for reporting illegal content has been submitted.'))
+            ->line(Lang::get('Name: ') . $this->name)
+            ->line(Lang::get('Email address: ') . $this->mailAddress)
+            ->line(Lang::get('Reason why the information in question is illegal content:'))
+            ->line($this->reason)
+            ->line('---')
+            ->line(Lang::get('URL(s) for the content in question:'))
+            ->line($this->offendingUrls)
+            ->line('---');
+    }
+}

--- a/app/Notifications/ExternalComplaintNotification.php
+++ b/app/Notifications/ExternalComplaintNotification.php
@@ -19,6 +19,12 @@ class ExternalComplaintNotification extends ComplaintNotification
      */
     public function toMail($notifiable)
     {
+        $name = $this->name;
+
+        if (empty($name)) {
+            $name = 'None';
+        }
+
         $mailFrom = config('app.complaint-mail-sender');
         $mailSubject = config('app.name') . ': Report of Illegal Content';
 
@@ -26,11 +32,10 @@ class ExternalComplaintNotification extends ComplaintNotification
             ->from($mailFrom)
             ->subject($mailSubject)
             ->line(Lang::get('Your message via the wikibase.cloud form for reporting illegal content has been submitted.'))
-            ->line(Lang::get('Name: ') . $this->name)
+            ->line(Lang::get('Name: ') . $name)
             ->line(Lang::get('Email address: ') . $this->mailAddress)
             ->line(Lang::get('Reason why the information in question is illegal content:'))
             ->line($this->reason)
-            ->line('---')
             ->line(Lang::get('URL(s) for the content in question:'))
             ->line($this->offendingUrls)
             ->line('---');

--- a/config/app.php
+++ b/config/app.php
@@ -10,6 +10,9 @@ return [
     'contact-mail-recipient' => env('WBSTACK_CONTACT_MAIL_RECIPIENT', 'wikibase-cloud-owner@lists.wikimedia.org'),
     'contact-mail-sender' => env('WBSTACK_CONTACT_MAIL_SENDER', 'contact-<subject>@wikibase.cloud'),
 
+    'complaint-mail-recipient' => env('WBSTACK_COMPLAINT_MAIL_RECIPIENT', 'dsa-meldung@wikimedia.de'),
+    'complaint-mail-sender' => env('WBSTACK_COMPLAINT_MAIL_SENDER', 'dsa@wikibase.cloud'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Name

--- a/database/factories/ComplaintRecordFactory.php
+++ b/database/factories/ComplaintRecordFactory.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Database\Factories;
+
+use App\ComplaintRecord;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @template TModel of \App\ComplaintRecord
+ *
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<TModel>
+ */
+class ComplaintRecordFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var class-string<TModel>
+     */
+    protected $model = ComplaintRecord::class;
+
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'dispatched' => null,
+        ];
+    }
+}

--- a/database/migrations/2025_07_18_103841_create_complaint_records_table.php
+++ b/database/migrations/2025_07_18_103841_create_complaint_records_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('complaint_records', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->timestamp('dispatched_at')->nullable();
+            $table->string('name')->nullable();
+            $table->string('mail_address')->nullable();
+            $table->text('reason');
+            $table->text('offending_urls');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('complaint_records');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -18,6 +18,7 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router) {
     $router->post('user/forgotPassword', ['uses' => 'Auth\ForgotPasswordController@sendResetLinkEmail']);
     $router->post('user/resetPassword', ['uses' => 'Auth\ResetPasswordController@reset']);
     $router->post('contact/sendMessage', ['uses' => 'ContactController@sendMessage']);
+    $router->post('complaint/sendMessage', ['uses' => 'ComplaintController@sendMessage']);
 
     $router->post('auth/login', ['uses' => 'Auth\LoginController@postLogin'])->name('login');
     // Authed

--- a/tests/Routes/Complaint/SendMessageTest.php
+++ b/tests/Routes/Complaint/SendMessageTest.php
@@ -18,19 +18,19 @@ class SendMessageTest extends TestCase
     protected $route = 'complaint/sendMessage';
 
     protected $postDataTemplateEmpty = [
-        'name'           => '',
-        'mailAddress'    => '',
-        'reason'         => '',
-        'offendingUrls'  => '',
-        'recaptcha'      => '',
+        'name'      => '',
+        'email'     => '',
+        'message'   => '',
+        'url'       => '',
+        'recaptcha' => '',
     ];
 
     protected $postDataTemplateFilled = [
-        'name'           => 'Jane Doe',
-        'mailAddress'    => 'jane.doe@example.com',
-        'reason'         => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
-        'offendingUrls'  => 'https://example.com/1, https://example.com/2, https://example.com/3',
-        'recaptcha'      => 'fake-token',
+        'name'      => 'Jane Doe',
+        'email'     => 'jane.doe@example.com',
+        'message'   => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+        'url'       => 'https://example.com/1, https://example.com/2, https://example.com/3',
+        'recaptcha' => 'fake-token',
     ];
 
     private function mockReCaptchaValidation($passes=true)
@@ -107,7 +107,7 @@ class SendMessageTest extends TestCase
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
-        $data['mailAddress'] = "invalid-mail-address";
+        $data['email'] = "invalid-mail-address";
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
 
@@ -123,7 +123,7 @@ class SendMessageTest extends TestCase
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
-        $data['mailAddress'] = "mail@example.com, foo@bar.com";
+        $data['email'] = "mail@example.com, foo@bar.com";
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
 
@@ -165,7 +165,7 @@ class SendMessageTest extends TestCase
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
-        $data['offendingUrls'] = str_repeat("Hi!", 10000);
+        $data['url'] = str_repeat("Hi!", 10000);
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
 
@@ -180,7 +180,7 @@ class SendMessageTest extends TestCase
 
         $data = $this->postDataTemplateFilled;
         $data['name'] = '';
-        $data['mailAddress'] = '';
+        $data['email'] = '';
 
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(200);

--- a/tests/Routes/Complaint/SendMessageTest.php
+++ b/tests/Routes/Complaint/SendMessageTest.php
@@ -81,7 +81,7 @@ class SendMessageTest extends TestCase
             return;
         }
 
-        $response->assertStatus(500);
+        $this->assertNotEquals($response->status(), 200);
 
         $this->assertComplaintRecorded();
         $this->assertComplaintNotMarkedAsDispatched();

--- a/tests/Routes/Complaint/SendMessageTest.php
+++ b/tests/Routes/Complaint/SendMessageTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace Tests\Routes\Complaint;
+
+use App\Notifications\ComplaintNotification;
+use App\Rules\ReCaptchaValidation;
+use Illuminate\Notifications\AnonymousNotifiable;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+use Tests\Feature\ReCaptchaValidationTest;
+
+class SendMessageTest extends TestCase
+{
+    protected $route = 'complaint/sendMessage';
+
+    protected $postDataTemplateEmpty = [
+        'name'           => '',
+        'mailAddress'    => '',
+        'reason'         => '',
+        'offendingUrls'  => '',
+        'recaptcha'      => '',
+    ];
+
+    protected $postDataTemplateFilled = [
+        'name'           => 'Jane Doe',
+        'mailAddress'    => 'jane.doe@example.com',
+        'reason'         => 'Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.',
+        'offendingUrls'  => 'https://example.com/1, https://example.com/2, https://example.com/3',
+        'recaptcha'      => 'fake-token',
+    ];
+
+    private function mockReCaptchaValidation($passes=true)
+    {
+        // replace injected ReCaptchaValidation class with mock (ComplaintController::$recaptchaValidation)
+        $mockRule = $this->createMock(ReCaptchaValidation::class);
+        $mockRule->method('passes')
+            ->willReturn($passes);
+    
+        $this->app->instance(ReCaptchaValidation::class, $mockRule);
+    }
+
+    public function testSendMessage_NoData()
+    {
+        $this->mockReCaptchaValidation(false);
+
+        $data = $this->postDataTemplateEmpty;
+
+        $response = $this->json('POST', $this->route, $data);
+        $response->assertStatus(401);
+    }
+
+    public function testSendMessage_InvalidMailAddress()
+    {
+        $this->mockReCaptchaValidation();
+
+        $data = $this->postDataTemplateFilled;
+        $data['mailAddress'] = "invalid-mail-address";
+        $response = $this->json('POST', $this->route, $data);
+        $response->assertStatus(400);
+    }
+
+    public function testSendMessage_ReasonTooLong()
+    {
+        $this->mockReCaptchaValidation();
+
+        $data = $this->postDataTemplateFilled;
+        $data['reason'] = str_repeat("Hi!", 10000);
+        $response = $this->json('POST', $this->route, $data);
+        $response->assertStatus(400);
+    }
+
+    public function testSendMessage_NameTooLong()
+    {
+        $this->mockReCaptchaValidation();
+
+        $data = $this->postDataTemplateFilled;
+        $data['name'] = str_repeat("Hi!", 10000);
+        $response = $this->json('POST', $this->route, $data);
+        $response->assertStatus(400);
+    }
+
+    public function testSendMessage_OffendingUrlsTooLong()
+    {
+        $this->mockReCaptchaValidation();
+
+        $data = $this->postDataTemplateFilled;
+        $data['offendingUrls'] = str_repeat("Hi!", 10000);
+        $response = $this->json('POST', $this->route, $data);
+        $response->assertStatus(400);
+    }
+
+
+    public function testSendMessage_NoNameNorMailAddress()
+    {
+        $this->mockReCaptchaValidation();
+        Notification::fake();
+
+        $data = $this->postDataTemplateFilled;
+        $data['name'] = '';
+        $data['mailAddress'] = '';
+
+        $response = $this->json('POST', $this->route, $data);
+        $response->assertStatus(200);
+    }
+
+    public function testSendMessage_Success()
+    {
+        $this->mockReCaptchaValidation();
+        Notification::fake();
+
+        $data = $this->postDataTemplateFilled;
+
+        $response = $this->json('POST', $this->route, $data);
+        $response->assertStatus(200);
+        Notification::assertSentTo(new AnonymousNotifiable(), ComplaintNotification::class, function ($notification) {
+            $this->assertSame(
+                "dsa@wikibase.cloud",
+                $notification->toMail(new AnonymousNotifiable())->from[0]
+            );
+            return true;
+        });
+    }
+
+    public function testSendMessage_RecaptchaFailure()
+    {
+        $this->mockReCaptchaValidation(false);
+        Notification::fake();
+
+        $response = $this->json('POST', $this->route, $this->postDataTemplateFilled);
+        $response->assertStatus(401);
+
+        Notification::assertNothingSent();
+    }
+}

--- a/tests/Routes/Complaint/SendMessageTest.php
+++ b/tests/Routes/Complaint/SendMessageTest.php
@@ -2,15 +2,19 @@
 
 namespace Tests\Routes\Complaint;
 
+use App\ComplaintRecord;
 use App\Notifications\ComplaintNotification;
 use App\Rules\ReCaptchaValidation;
 use Illuminate\Notifications\AnonymousNotifiable;
 use Illuminate\Support\Facades\Notification;
 use Tests\TestCase;
 use Tests\Feature\ReCaptchaValidationTest;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
 class SendMessageTest extends TestCase
 {
+    use RefreshDatabase;
+    
     protected $route = 'complaint/sendMessage';
 
     protected $postDataTemplateEmpty = [
@@ -38,71 +42,141 @@ class SendMessageTest extends TestCase
     
         $this->app->instance(ReCaptchaValidation::class, $mockRule);
     }
+    private function assertRecordCount(int $count)
+    {
+        $this->assertEquals(ComplaintRecord::count(), $count);
+    }
+
+    private function assertComplaintMarkedAsDispatched()
+    {
+        $complaintRecord = ComplaintRecord::first();
+        $this->assertNotEmpty($complaintRecord->dispatched_at);
+    }
+
+    private function assertComplaintNotMarkedAsDispatched()
+    {
+        $complaintRecord = ComplaintRecord::first();
+        $this->assertEmpty($complaintRecord->dispatched_at);
+    }
+
+    private function assertComplaintRecorded()
+    {
+        $this->assertRecordCount(1);
+    }
+
+    private function assertComplaintNotRecorded()
+    {
+        $this->assertRecordCount(0);
+    }
+
+    public function testRecordOnMailFail()
+    {
+        $this->mockReCaptchaValidation();
+
+        $data = $this->postDataTemplateFilled;
+
+        try {
+            $response = $this->json('POST', $this->route, $data);
+        } catch(\Symfony\Component\Mailer\Exception\TransportException $e) {
+            return;
+        }
+
+        $response->assertStatus(500);
+
+        $this->assertComplaintRecorded();
+        $this->assertComplaintNotMarkedAsDispatched();
+    }
 
     public function testSendMessage_NoData()
     {
+        Notification::fake();
         $this->mockReCaptchaValidation(false);
 
         $data = $this->postDataTemplateEmpty;
 
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(401);
+
+        Notification::assertNothingSent();
+        $this->assertComplaintNotRecorded();
     }
 
     public function testSendMessage_InvalidMailAddressRfc()
     {
+        Notification::fake();
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
         $data['mailAddress'] = "invalid-mail-address";
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
+
+        $this->assertEquals(ComplaintRecord::count(), 0);
+
+        Notification::assertNothingSent();
+        $this->assertComplaintNotRecorded();
     }
 
     public function testSendMessage_InvalidMailAddressMulti()
     {
+        Notification::fake();
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
         $data['mailAddress'] = "mail@example.com, foo@bar.com";
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
+
+        Notification::assertNothingSent();
+        $this->assertComplaintNotRecorded();
     }
 
     public function testSendMessage_ReasonTooLong()
     {
+        Notification::fake();
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
         $data['reason'] = str_repeat("Hi!", 10000);
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
+
+        Notification::assertNothingSent();
+        $this->assertComplaintNotRecorded();
     }
 
     public function testSendMessage_NameTooLong()
     {
+        Notification::fake();
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
         $data['name'] = str_repeat("Hi!", 10000);
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
+
+        Notification::assertNothingSent();
+        $this->assertComplaintNotRecorded();
     }
 
     public function testSendMessage_OffendingUrlsTooLong()
     {
+        Notification::fake();
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
         $data['offendingUrls'] = str_repeat("Hi!", 10000);
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
+
+        Notification::assertNothingSent();
+        $this->assertComplaintNotRecorded();
     }
 
     public function testSendMessage_NoNameNorMailAddress()
     {
-        $this->mockReCaptchaValidation();
         Notification::fake();
+        $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
         $data['name'] = '';
@@ -110,12 +184,16 @@ class SendMessageTest extends TestCase
 
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(200);
+
+        Notification::assertCount(1);
+        $this->assertComplaintRecorded();
+        $this->assertComplaintMarkedAsDispatched();
     }
 
     public function testSendMessage_Success()
     {
-        $this->mockReCaptchaValidation();
         Notification::fake();
+        $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
 
@@ -128,16 +206,21 @@ class SendMessageTest extends TestCase
             );
             return true;
         });
+
+        Notification::assertCount(2);
+        $this->assertComplaintRecorded();
+        $this->assertComplaintMarkedAsDispatched();
     }
 
     public function testSendMessage_RecaptchaFailure()
     {
-        $this->mockReCaptchaValidation(false);
         Notification::fake();
+        $this->mockReCaptchaValidation(false);
 
         $response = $this->json('POST', $this->route, $this->postDataTemplateFilled);
         $response->assertStatus(401);
 
         Notification::assertNothingSent();
+        $this->assertComplaintNotRecorded();
     }
 }

--- a/tests/Routes/Complaint/SendMessageTest.php
+++ b/tests/Routes/Complaint/SendMessageTest.php
@@ -137,7 +137,7 @@ class SendMessageTest extends TestCase
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
-        $data['reason'] = str_repeat("Hi!", 10000);
+        $data['message'] = str_repeat("Hi!", 10000);
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
 

--- a/tests/Routes/Complaint/SendMessageTest.php
+++ b/tests/Routes/Complaint/SendMessageTest.php
@@ -49,12 +49,22 @@ class SendMessageTest extends TestCase
         $response->assertStatus(401);
     }
 
-    public function testSendMessage_InvalidMailAddress()
+    public function testSendMessage_InvalidMailAddressRfc()
     {
         $this->mockReCaptchaValidation();
 
         $data = $this->postDataTemplateFilled;
         $data['mailAddress'] = "invalid-mail-address";
+        $response = $this->json('POST', $this->route, $data);
+        $response->assertStatus(400);
+    }
+
+    public function testSendMessage_InvalidMailAddressMulti()
+    {
+        $this->mockReCaptchaValidation();
+
+        $data = $this->postDataTemplateFilled;
+        $data['mailAddress'] = "mail@example.com, foo@bar.com";
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
     }
@@ -88,7 +98,6 @@ class SendMessageTest extends TestCase
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(400);
     }
-
 
     public function testSendMessage_NoNameNorMailAddress()
     {


### PR DESCRIPTION
https://phabricator.wikimedia.org/T397905

* this adds new Classes:
  * ComplaintRecord
    * persists incoming form data, before trying to send mails
  * ComplaintController
    * handles new form route `/complaint/sendMessage` 
  * ComplaintNotification
    * Internal mail template
  * ComplaintNotificationExternal
    * External mail template (user confirmation)

### what I need help with:
the test case `testRecordOnMailFail`  can successfully test if the input gets persisted even if we can't send the mails, but as this triggers an Exception it pollutes the test suite output