### PR TITLE
wikiMetrics: fix zero count occassions

### DIFF
--- a/app/Metrics/App/WikiMetrics.php
+++ b/app/Metrics/App/WikiMetrics.php
@@ -199,10 +199,15 @@ class WikiMetrics {
         $conn = $manager->connection('mw');
         $pdo = $conn->getPdo();
         $result = $pdo->query($query)->fetchAll(PDO::FETCH_ASSOC);
-        if (count($result) === 0) {
-            return [120 => 0, 122 => 0, 146 => 0, 640 => 0];
-        }
 
-        return array_column($result, 'count', 'namespace');
+        $result = array_column($result, 'count', 'namespace');
+
+        // make sure the array keys are set
+        $result[120] ??= 0;
+        $result[122] ??= 0;
+        $result[146] ??= 0;
+        $result[640] ??= 0;
+
+        return $result;
     }
 }

--- a/tests/Metrics/WikiMetricsTest.php
+++ b/tests/Metrics/WikiMetricsTest.php
@@ -168,8 +168,7 @@ class WikiMetricsTest extends TestCase {
         ]);
     }
 
-    public static function dummyDataProvider()
-    {
+    public static function dummyDataProvider() {
         $item1 = [
             'page_namespace' => 120,
             'page_is_redirect' => 0,
@@ -197,7 +196,7 @@ class WikiMetricsTest extends TestCase {
             'page_random' => 0,
             'page_touched' => random_bytes(10),
             'page_latest' => 1,
-            'page_len' => 2
+            'page_len' => 2,
         ];
 
         $entitySchema = [

--- a/tests/Metrics/WikiMetricsTest.php
+++ b/tests/Metrics/WikiMetricsTest.php
@@ -168,7 +168,7 @@ class WikiMetricsTest extends TestCase {
         ]);
     }
 
-    static public function dummyDataProvider()
+    public static function dummyDataProvider()
     {
         $item1 = [
             'page_namespace' => 120,

--- a/tests/Metrics/WikiMetricsTest.php
+++ b/tests/Metrics/WikiMetricsTest.php
@@ -243,7 +243,7 @@ class WikiMetricsTest extends TestCase {
                 $lexeme,
                 $entitySchema,
                 $entitySchemaRedirect,
-            ]
+            ],
         ];
         
         // zero items
@@ -260,7 +260,7 @@ class WikiMetricsTest extends TestCase {
                 $lexeme,
                 $entitySchema,
                 $entitySchemaRedirect,
-            ]
+            ],
         ];
 
         // zero properties
@@ -277,7 +277,7 @@ class WikiMetricsTest extends TestCase {
                 $lexeme,
                 $entitySchema,
                 $entitySchemaRedirect,
-            ]
+            ],
         ];
 
         // zero Lexemes
@@ -294,7 +294,7 @@ class WikiMetricsTest extends TestCase {
                 // $lexeme,
                 $entitySchema,
                 $entitySchemaRedirect,
-            ]
+            ],
         ];
 
         // zero EntitySchemas
@@ -311,7 +311,7 @@ class WikiMetricsTest extends TestCase {
                 $lexeme,
                 // $entitySchema,
                 $entitySchemaRedirect, // should not count
-            ]
+            ],
         ];
     }
 

--- a/tests/Metrics/WikiMetricsTest.php
+++ b/tests/Metrics/WikiMetricsTest.php
@@ -168,7 +168,158 @@ class WikiMetricsTest extends TestCase {
         ]);
     }
 
-    public function testSavesEntityCountsCorrectly() {
+    static public function dummyDataProvider()
+    {
+        $item1 = [
+            'page_namespace' => 120,
+            'page_is_redirect' => 0,
+            'page_title' => 'foo',
+            'page_random' => 0,
+            'page_touched' => random_bytes(10),
+            'page_latest' => 1,
+            'page_len' => 2,
+        ];
+
+        $item2 = [
+            'page_namespace' => 120,
+            'page_is_redirect' => 0,
+            'page_title' => 'bar',
+            'page_random' => 0,
+            'page_touched' => random_bytes(10),
+            'page_latest' => 0,
+            'page_len' => 2,
+        ];
+            
+        $property = [
+            'page_namespace' => 122,
+            'page_is_redirect' => 0,
+            'page_title' => 'foo',
+            'page_random' => 0,
+            'page_touched' => random_bytes(10),
+            'page_latest' => 1,
+            'page_len' => 2
+        ];
+
+        $entitySchema = [
+            'page_namespace' => 640,
+            'page_is_redirect' => 0,
+            'page_title' => 'bar',
+            'page_random' => 0,
+            'page_touched' => random_bytes(10),
+            'page_latest' => 1,
+            'page_len' => 2,
+        ];
+
+        $entitySchemaRedirect = [
+            'page_namespace' => 640,
+            'page_is_redirect' => 1,
+            'page_title' => 'foo',
+            'page_random' => 0,
+            'page_touched' => random_bytes(10),
+            'page_latest' => 1,
+            'page_len' => 2,
+        ];
+
+        $lexeme = [
+            'page_namespace' => 146,
+            'page_is_redirect' => 0,
+            'page_title' => 'foo',
+            'page_random' => 0,
+            'page_touched' => random_bytes(10),
+            'page_latest' => 1,
+            'page_len' => 2,
+        ];
+
+        // all relevant data types
+        yield [
+            'expectedItemCount' => 2,
+            'expectedPropertyCount' => 1,
+            'expectedLexemeCount' => 1,
+            'expectedEntitySchemaCount' => 1,
+
+            'pageData' => [
+                $item1,
+                $item2,
+                $property,
+                $lexeme,
+                $entitySchema,
+                $entitySchemaRedirect,
+            ]
+        ];
+        
+        // zero items
+        yield [
+            'expectedItemCount' => 0,
+            'expectedPropertyCount' => 1,
+            'expectedLexemeCount' => 1,
+            'expectedEntitySchemaCount' => 1,
+            
+            'pageData' => [
+                // $item1,
+                // $item2,
+                $property,
+                $lexeme,
+                $entitySchema,
+                $entitySchemaRedirect,
+            ]
+        ];
+
+        // zero properties
+        yield [
+            'expectedItemCount' => 2,
+            'expectedPropertyCount' => 0,
+            'expectedLexemeCount' => 1,
+            'expectedEntitySchemaCount' => 1,
+            
+            'pageData' => [
+                $item1,
+                $item2,
+                // $property,
+                $lexeme,
+                $entitySchema,
+                $entitySchemaRedirect,
+            ]
+        ];
+
+        // zero Lexemes
+        yield [
+            'expectedItemCount' => 2,
+            'expectedPropertyCount' => 1,
+            'expectedLexemeCount' => 0,
+            'expectedEntitySchemaCount' => 1,
+            
+            'pageData' => [
+                $item1,
+                $item2,
+                $property,
+                // $lexeme,
+                $entitySchema,
+                $entitySchemaRedirect,
+            ]
+        ];
+
+        // zero EntitySchemas
+        yield [
+            'expectedItemCount' => 2,
+            'expectedPropertyCount' => 1,
+            'expectedLexemeCount' => 1,
+            'expectedEntitySchemaCount' => 0,
+            
+            'pageData' => [
+                $item1,
+                $item2,
+                $property,
+                $lexeme,
+                // $entitySchema,
+                $entitySchemaRedirect, // should not count
+            ]
+        ];
+    }
+
+    /**
+     * @dataProvider dummyDataProvider
+     */
+    public function testSavesEntityCountsCorrectly($expectedItemCount, $expectedPropertyCount, $expectedLexemeCount, $expectedEntitySchemaCount, $pageData) {
         $wiki = Wiki::factory()->create([
             'domain' => 'entitycounttest.wikibase.cloud',
         ]);
@@ -191,66 +342,12 @@ class WikiMetricsTest extends TestCase {
         });
 
         // Insert dummy data
-        DB::table($tablePage)->insert([
-            [
-                'page_namespace' => 120,
-                'page_is_redirect' => 0,
-                'page_title' => 'foo',
-                'page_random' => 0,
-                'page_touched' => random_bytes(10),
-                'page_latest' => 1,
-                'page_len' => 2,
-            ], // item
-            [
-                'page_namespace' => 120,
-                'page_is_redirect' => 0,
-                'page_title' => 'bar',
-                'page_random' => 0,
-                'page_touched' => random_bytes(10),
-                'page_latest' => 0,
-                'page_len' => 2,
-            ], // item
-            [
-                'page_namespace' => 122,
-                'page_is_redirect' => 0,
-                'page_title' => 'foo',
-                'page_random' => 0,
-                'page_touched' => random_bytes(10),
-                'page_latest' => 1,
-                'page_len' => 2], // property
-            [
-                'page_namespace' => 640,
-                'page_is_redirect' => 0,
-                'page_title' => 'bar',
-                'page_random' => 0,
-                'page_touched' => random_bytes(10),
-                'page_latest' => 1,
-                'page_len' => 2,
-            ], // entity schema
-            [
-                'page_namespace' => 146,
-                'page_is_redirect' => 0,
-                'page_title' => 'foo',
-                'page_random' => 0,
-                'page_touched' => random_bytes(10),
-                'page_latest' => 1,
-                'page_len' => 2,
-            ], // lexeme
-            [
-                'page_namespace' => 640,
-                'page_is_redirect' => 1,
-                'page_title' => 'foo',
-                'page_random' => 0,
-                'page_touched' => random_bytes(10),
-                'page_latest' => 1,
-                'page_len' => 2,
-            ], // entity schema
-        ]);
+        DB::table($tablePage)->insert($pageData);
         WikiDailyMetrics::create([
             'id' => $wiki->id . '_' . now()->subDay()->toDateString(),
             'wiki_id' => $wiki->id,
             'date' => now()->subDay()->toDateString(),
-            'pages' => 6,
+            'pages' => count($pageData),
             'is_deleted' => 0,
         ]);
 
@@ -262,10 +359,10 @@ class WikiMetricsTest extends TestCase {
 
         $this->assertDatabaseHas('wiki_daily_metrics', [
             'wiki_id' => $wiki->id,
-            'item_count' => 2,
-            'property_count' => 1,
-            'lexeme_count' => 1,
-            'entity_schema_count' => 1, // the redirect should be ignored
+            'item_count' => $expectedItemCount,
+            'property_count' => $expectedPropertyCount,
+            'lexeme_count' => $expectedLexemeCount,
+            'entity_schema_count' => $expectedEntitySchemaCount, // redirects should be ignored
         ]);
     }
 }

--- a/tests/Metrics/WikiMetricsTest.php
+++ b/tests/Metrics/WikiMetricsTest.php
@@ -188,7 +188,7 @@ class WikiMetricsTest extends TestCase {
             'page_latest' => 0,
             'page_len' => 2,
         ];
-            
+
         $property = [
             'page_namespace' => 122,
             'page_is_redirect' => 0,
@@ -245,14 +245,14 @@ class WikiMetricsTest extends TestCase {
                 $entitySchemaRedirect,
             ],
         ];
-        
+
         // zero items
         yield [
             'expectedItemCount' => 0,
             'expectedPropertyCount' => 1,
             'expectedLexemeCount' => 1,
             'expectedEntitySchemaCount' => 1,
-            
+
             'pageData' => [
                 // $item1,
                 // $item2,
@@ -269,7 +269,7 @@ class WikiMetricsTest extends TestCase {
             'expectedPropertyCount' => 0,
             'expectedLexemeCount' => 1,
             'expectedEntitySchemaCount' => 1,
-            
+
             'pageData' => [
                 $item1,
                 $item2,
@@ -286,7 +286,7 @@ class WikiMetricsTest extends TestCase {
             'expectedPropertyCount' => 1,
             'expectedLexemeCount' => 0,
             'expectedEntitySchemaCount' => 1,
-            
+
             'pageData' => [
                 $item1,
                 $item2,
@@ -303,7 +303,7 @@ class WikiMetricsTest extends TestCase {
             'expectedPropertyCount' => 1,
             'expectedLexemeCount' => 1,
             'expectedEntitySchemaCount' => 0,
-            
+
             'pageData' => [
                 $item1,
                 $item2,


### PR DESCRIPTION
We've seen[1] an error in the current WikiMetrics code in case there are zero entries for a type of entity metrics, but not zero in total: https://github.com/wbstack/api/blob/main/app/Metrics/App/WikiMetrics.php#L202

This PR attempts to provide a fix and extends the test case for this type of error.

[1] https://console.cloud.google.com/errors/detail/CIiQvbv5l_3pHA;locations=global;time=P30D?project=wikibase-cloud&utm_source=error-reporting-notification&utm_medium=email&utm_content=new-error
