### PR TITLE
Add `reuse_prototype` field to `/wiki` API endpoint

### DIFF
--- a/app/Http/Controllers/PublicWikiController.php
+++ b/app/Http/Controllers/PublicWikiController.php
@@ -29,7 +29,7 @@ class PublicWikiController extends Controller {
         ]);
 
         $params = array_merge(self::$defaultParams, $request->input());
-        $query = Wiki::query();
+        $query = Wiki::query()->with('wikiLatestProfile');
 
         if (array_key_exists('is_featured', $params)) {
             $query = $query->where([

--- a/app/Http/Controllers/PublicWikiController.php
+++ b/app/Http/Controllers/PublicWikiController.php
@@ -72,6 +72,6 @@ class PublicWikiController extends Controller {
      * Display the specified resource.
      */
     public function show($id) {
-        return new PublicWikiResource(Wiki::findOrFail($id));
+        return new PublicWikiResource(Wiki::query()->with('wikiLatestProfile')->findOrFail($id));
     }
 }

--- a/app/Http/Controllers/PublicWikiController.php
+++ b/app/Http/Controllers/PublicWikiController.php
@@ -29,6 +29,7 @@ class PublicWikiController extends Controller {
         ]);
 
         $params = array_merge(self::$defaultParams, $request->input());
+        // eager load 'wikiLatestProfile' to avoid making N+1 queries
         $query = Wiki::query()->with('wikiLatestProfile');
 
         if (array_key_exists('is_featured', $params)) {

--- a/app/Http/Controllers/PublicWikiController.php
+++ b/app/Http/Controllers/PublicWikiController.php
@@ -72,6 +72,6 @@ class PublicWikiController extends Controller {
      * Display the specified resource.
      */
     public function show($id) {
-        return new PublicWikiResource(Wiki::query()->with('wikiLatestProfile')->findOrFail($id));
+        return new PublicWikiResource(Wiki::findOrFail($id));
     }
 }

--- a/app/Http/Resources/PublicWikiResource.php
+++ b/app/Http/Resources/PublicWikiResource.php
@@ -16,6 +16,21 @@ class PublicWikiResource extends JsonResource {
             'sitename' => $this->sitename,
             'wiki_site_stats' => $this->wikiSiteStats,
             'logo_url' => $logoSetting ? $logoSetting->value : null,
+
+            // TODO: delete these three fields before merging; here to easily prove the `reuse_prototype` logic works
+            'test_purpose' => $this->wikiLatestProfile ? $this->wikiLatestProfile->purpose : null,
+            'test_temporality' => $this->wikiLatestProfile ? $this->wikiLatestProfile->temporality : null,
+            'test_audience' => $this->wikiLatestProfile ? $this->wikiLatestProfile->audience : null,
+
+            // TODO: As the `$this->wikiLatestProfile` property can be accessed regardless of if
+            // `->with('wikiLatestProfile')` is used in the controller, we are unable to return null if
+            // `$this->wikiLatestProfile` isn't set. We should either look into addressing this, or remove the
+            // `$this->wikiLatestProfile ? ... : null` conditional.
+            'reuse_prototype' => $this->wikiLatestProfile
+                ? $this->wikiLatestProfile->purpose === 'data_hub'
+                  && $this->wikiLatestProfile->temporality === 'permanent'
+                  && $this->wikiLatestProfile->audience === 'wide'
+                : null,
         ];
     }
 }

--- a/app/Http/Resources/PublicWikiResource.php
+++ b/app/Http/Resources/PublicWikiResource.php
@@ -19,12 +19,10 @@ class PublicWikiResource extends JsonResource {
 
             // Checking relation load state before reading it to avoid N+1 query
             // This relies on the controller to eager load `wikiLatestProfile` relationship
-            'reuse_prototype' => $this->relationLoaded('wikiLatestProfile')
-                ? ($this->wikiLatestProfile
-                    ? $this->wikiLatestProfile->purpose === 'data_hub'
-                    && $this->wikiLatestProfile->temporality === 'permanent'
-                    && $this->wikiLatestProfile->audience === 'wide'
-                    : null)
+            'reuse_prototype' => $this->wikiLatestProfile
+                ? $this->wikiLatestProfile->purpose === 'data_hub'
+                  && $this->wikiLatestProfile->temporality === 'permanent'
+                  && $this->wikiLatestProfile->audience === 'wide'
                 : null,
         ];
     }

--- a/app/Http/Resources/PublicWikiResource.php
+++ b/app/Http/Resources/PublicWikiResource.php
@@ -17,11 +17,6 @@ class PublicWikiResource extends JsonResource {
             'wiki_site_stats' => $this->wikiSiteStats,
             'logo_url' => $logoSetting ? $logoSetting->value : null,
 
-            // TODO: delete these three fields before merging; here to easily prove the `reuse_prototype` logic works
-            'test_purpose' => $this->wikiLatestProfile ? $this->wikiLatestProfile->purpose : null,
-            'test_temporality' => $this->wikiLatestProfile ? $this->wikiLatestProfile->temporality : null,
-            'test_audience' => $this->wikiLatestProfile ? $this->wikiLatestProfile->audience : null,
-
             // Checking relation load state before reading it to avoid N+1 query
             // This relies on the controller to eager load `wikiLatestProfile` relationship
             'reuse_prototype' => $this->relationLoaded('wikiLatestProfile')

--- a/app/Http/Resources/PublicWikiResource.php
+++ b/app/Http/Resources/PublicWikiResource.php
@@ -22,14 +22,14 @@ class PublicWikiResource extends JsonResource {
             'test_temporality' => $this->wikiLatestProfile ? $this->wikiLatestProfile->temporality : null,
             'test_audience' => $this->wikiLatestProfile ? $this->wikiLatestProfile->audience : null,
 
-            // TODO: As the `$this->wikiLatestProfile` property can be accessed regardless of if
-            // `->with('wikiLatestProfile')` is used in the controller, we are unable to return null if
-            // `$this->wikiLatestProfile` isn't set. We should either look into addressing this, or remove the
-            // `$this->wikiLatestProfile ? ... : null` conditional.
-            'reuse_prototype' => $this->wikiLatestProfile
-                ? $this->wikiLatestProfile->purpose === 'data_hub'
-                  && $this->wikiLatestProfile->temporality === 'permanent'
-                  && $this->wikiLatestProfile->audience === 'wide'
+            // Checking relation load state before reading it to avoid N+1 query
+            // This relies on the controller to eager load `wikiLatestProfile` relationship
+            'reuse_prototype' => $this->relationLoaded('wikiLatestProfile')
+                ? ($this->wikiLatestProfile
+                    ? $this->wikiLatestProfile->purpose === 'data_hub'
+                    && $this->wikiLatestProfile->temporality === 'permanent'
+                    && $this->wikiLatestProfile->audience === 'wide'
+                    : null)
                 : null,
         ];
     }

--- a/app/Http/Resources/PublicWikiResource.php
+++ b/app/Http/Resources/PublicWikiResource.php
@@ -16,14 +16,11 @@ class PublicWikiResource extends JsonResource {
             'sitename' => $this->sitename,
             'wiki_site_stats' => $this->wikiSiteStats,
             'logo_url' => $logoSetting ? $logoSetting->value : null,
-
-            // Checking relation load state before reading it to avoid N+1 query
-            // This relies on the controller to eager load `wikiLatestProfile` relationship
             'reuse_prototype' => $this->wikiLatestProfile
                 ? $this->wikiLatestProfile->purpose === 'data_hub'
                   && $this->wikiLatestProfile->temporality === 'permanent'
                   && $this->wikiLatestProfile->audience === 'wide'
-                : null,
+                : false,
         ];
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -26,16 +26,5 @@ class AppServiceProvider extends ServiceProvider {
             $wrappedException = new \Exception("Executing Job '$name' failed.", 1, $event->exception);
             report($wrappedException);
         });
-
-        // Local-only SQL query logging for debugging
-        if ($this->app->environment('local')) {
-            \Event::listen(QueryExecuted::class, function (QueryExecuted $query) {
-                \Log::debug('Query Executed: ', [
-                    'sql' => $query->sql,
-                    'bindings' => $query->bindings,
-                    'connection' => $query->connectionName,
-                ]);
-            });
-        }
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -27,7 +27,7 @@ class AppServiceProvider extends ServiceProvider {
             report($wrappedException);
         });
 
-        // TODO: delete this listener before merging or is it useful to keep in the local environment?
+        // Local-only SQL query logging for debugging
         if ($this->app->environment('local')) {
             \Event::listen(QueryExecuted::class, function (QueryExecuted $query) {
                 \Log::debug('Query Executed: ', [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,7 +4,6 @@ namespace App\Providers;
 
 use App\Http\Curl\CurlRequest;
 use App\Http\Curl\HttpRequest;
-use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\ServiceProvider;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,6 +4,7 @@ namespace App\Providers;
 
 use App\Http\Curl\CurlRequest;
 use App\Http\Curl\HttpRequest;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Queue\Events\JobFailed;
 use Illuminate\Support\Facades\Queue;
 use Illuminate\Support\ServiceProvider;
@@ -25,5 +26,16 @@ class AppServiceProvider extends ServiceProvider {
             $wrappedException = new \Exception("Executing Job '$name' failed.", 1, $event->exception);
             report($wrappedException);
         });
+
+        // TODO: delete this listener before merging or is it useful to keep in the local environment?
+        if ($this->app->environment('local')) {
+            \Event::listen(QueryExecuted::class, function (QueryExecuted $query) {
+                \Log::debug('Query Executed: ', [
+                    'sql' => $query->sql,
+                    'bindings' => $query->bindings,
+                    'connection' => $query->connectionName,
+                ]);
+            });
+        }
     }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,5 +57,6 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router): v
     });
 
     $router->apiResource('wiki', 'PublicWikiController')->only(['index', 'show']);
+    $router->apiResource('reusePrototype', 'PublicWikiController')->only(['index', 'show']);
     $router->apiResource('wikiConversionData', 'ConversionMetricController')->only(['index']);
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -57,6 +57,6 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router): v
     });
 
     $router->apiResource('wiki', 'PublicWikiController')->only(['index', 'show']);
-    $router->apiResource('reusePrototype', 'PublicWikiController')->only(['index', 'show']);
+    $router->apiResource('reusePrototype', 'PublicWikiController')->only(['index']);
     $router->apiResource('wikiConversionData', 'ConversionMetricController')->only(['index']);
 });

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -35,7 +35,7 @@ class PublicWikiControllerTest extends TestCase {
         $this->assertSame(true, $resource->toArray(new Request)['reuse_prototype']);
     }
 
-    public function testIndexEagerLoadsWikiLatestProfileOnceForCollection(): void {
+    public function testIndexReusePrototypeOnlyRequiresOneAdditionalDatabaseQuery(): void {
         for ($i = 1; $i <= 3; $i++) {
             $wiki = Wiki::factory()->create([
                 'domain' => "index-eager-load-test-{$i}.wikibase.cloud",
@@ -64,7 +64,7 @@ class PublicWikiControllerTest extends TestCase {
         $this->assertTrue($resourceCollection->first()->relationLoaded('wikiLatestProfile'));
     }
 
-    public function testIndexReturnsFalseWhenWikiHasNoLatestProfile(): void {
+    public function testIndexReusePrototypeIsFalseWhenWikiHasNoLatestProfile(): void {
         $wikiWithoutProfile = Wiki::factory()->create([
             'domain' => 'no-profile.wikibase.cloud',
             'sitename' => 'No Profile Test Site',
@@ -80,7 +80,7 @@ class PublicWikiControllerTest extends TestCase {
         $this->assertFalse($resource->toArray($request)['reuse_prototype']);
     }
 
-    public function testIndexReturnsFalseWhenWikiLatestProfileDoesNotMatchReusePrototype(): void {
+    public function testIndexReusePrototypeIsFalseWhenWikiIsNotIntendedForReuse(): void {
         $incompleteProfileWiki = Wiki::factory()->create([
             'domain' => 'incomplete-profile.wikibase.cloud',
             'sitename' => 'Incomplete Profile Test Site',

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -50,17 +50,17 @@ class PublicWikiControllerTest extends TestCase {
             ]);
         }
 
-        $wikiProfileQueryCount = 0;
-        DB::listen(function (QueryExecuted $query) use (&$wikiProfileQueryCount): void {
+        $wikiProfilesQueryCount = 0;
+        DB::listen(function (QueryExecuted $query) use (&$wikiProfilesQueryCount): void {
             if (str_contains($query->sql, 'wiki_profiles')) {
-                $wikiProfileQueryCount++;
+                $wikiProfilesQueryCount++;
             }
         });
 
         $controller = new PublicWikiController;
         $resourceCollection = $controller->index(new Request);
 
-        $this->assertSame(1, $wikiProfileQueryCount);
+        $this->assertSame(1, $wikiProfilesQueryCount);
         $this->assertTrue($resourceCollection->first()->relationLoaded('wikiLatestProfile'));
     }
 

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -29,6 +29,6 @@ class PublicWikiControllerTest extends TestCase {
         $resource = $controller->show($wiki->id);
 
         $this->assertInstanceOf(PublicWikiResource::class, $resource);
-        $this->assertSame(true, $resource->toArray(request())['reuse_prototype']);
+        $this->assertTrue($resource->resource->relationLoaded('wikiLatestProfile'));
     }
 }

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -8,13 +8,14 @@ use App\Wiki;
 use App\WikiProfile;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class PublicWikiControllerTest extends TestCase {
     use DatabaseTransactions;
 
-    public function testShowEagerLoadsWikiLatestProfileForResource(): void {
+    public function testShowLoadsWikiLatestProfileForResource(): void {
         $wiki = Wiki::factory()->create([
             'domain' => 'controller-test.wikibase.cloud',
             'sitename' => 'controller-test',
@@ -31,14 +32,14 @@ class PublicWikiControllerTest extends TestCase {
         $resource = $controller->show($wiki->id);
 
         $this->assertInstanceOf(PublicWikiResource::class, $resource);
-        $this->assertTrue($resource->resource->relationLoaded('wikiLatestProfile'));
+        $this->assertSame(true, $resource->toArray(new Request)['reuse_prototype']);
     }
 
     public function testIndexEagerLoadsWikiLatestProfileOnceForCollection(): void {
-        for ($i = 1; $i <= rand(3, 100); $i++) {
+        for ($i = 1; $i <= 3; $i++) {
             $wiki = Wiki::factory()->create([
-                'domain' => 'index-eager-load-test-' . $i . '.wikibase.cloud',
-                'sitename' => 'Index Eager Load Test Site ' . $i,
+                'domain' => "index-eager-load-test-{$i}.wikibase.cloud",
+                'sitename' => "Index Eager Load Test Site {$i}",
             ]);
 
             WikiProfile::create([
@@ -57,9 +58,9 @@ class PublicWikiControllerTest extends TestCase {
         });
 
         $controller = new PublicWikiController;
-        $resourceCollection = $controller->index(request());
+        $resourceCollection = $controller->index(new Request);
 
         $this->assertSame(1, $profileQueryCount);
-        $this->assertTrue($resourceCollection->collection[0]->resource->relationLoaded('wikiLatestProfile'));
+        $this->assertTrue($resourceCollection->first()->relationLoaded('wikiLatestProfile'));
     }
 }

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -6,7 +6,9 @@ use App\Http\Controllers\PublicWikiController;
 use App\Http\Resources\PublicWikiResource;
 use App\Wiki;
 use App\WikiProfile;
+use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class PublicWikiControllerTest extends TestCase {
@@ -30,5 +32,36 @@ class PublicWikiControllerTest extends TestCase {
 
         $this->assertInstanceOf(PublicWikiResource::class, $resource);
         $this->assertTrue($resource->resource->relationLoaded('wikiLatestProfile'));
+    }
+
+    public function testIndexEagerLoadsWikiLatestProfileOnceForCollection(): void {
+        $n = rand(3, 100);
+        echo $n;
+        for ($i = 1; $i <= $n; $i++) {
+            $wiki = Wiki::factory()->create([
+                'domain' => 'index-eager-load-test-' . $i . '.wikibase.cloud',
+                'sitename' => 'Index Eager Load Test Site ' . $i,
+            ]);
+
+            WikiProfile::create([
+                'wiki_id' => $wiki->id,
+                'purpose' => 'data_hub',
+                'temporality' => 'permanent',
+                'audience' => 'wide',
+            ]);
+        }
+
+        $profileQueryCount = 0;
+        DB::listen(function (QueryExecuted $query) use (&$profileQueryCount): void {
+            if (str_contains($query->sql, 'wiki_profiles')) {
+                $profileQueryCount++;
+            }
+        });
+
+        $controller = new PublicWikiController;
+        $resourceCollection = $controller->index(request());
+
+        $this->assertSame(1, $profileQueryCount);
+        $this->assertTrue($resourceCollection->collection[0]->resource->relationLoaded('wikiLatestProfile'));
     }
 }

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -50,17 +50,17 @@ class PublicWikiControllerTest extends TestCase {
             ]);
         }
 
-        $profileQueryCount = 0;
-        DB::listen(function (QueryExecuted $query) use (&$profileQueryCount): void {
+        $wikiProfileQueryCount = 0;
+        DB::listen(function (QueryExecuted $query) use (&$wikiProfileQueryCount): void {
             if (str_contains($query->sql, 'wiki_profiles')) {
-                $profileQueryCount++;
+                $wikiProfileQueryCount++;
             }
         });
 
         $controller = new PublicWikiController;
         $resourceCollection = $controller->index(new Request);
 
-        $this->assertSame(1, $profileQueryCount);
+        $this->assertSame(1, $wikiProfileQueryCount);
         $this->assertTrue($resourceCollection->first()->relationLoaded('wikiLatestProfile'));
     }
 }

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -81,22 +81,21 @@ class PublicWikiControllerTest extends TestCase {
     }
 
     public function testIndexReusePrototypeIsFalseWhenWikiIsNotIntendedForReuse(): void {
-        $incompleteProfileWiki = Wiki::factory()->create([
-            'domain' => 'incomplete-profile.wikibase.cloud',
-            'sitename' => 'Incomplete Profile Test Site',
+        $wiki = Wiki::factory()->create([
+            'domain' => 'not-intended-for-reuse.wikibase.cloud',
+            'sitename' => 'Not Intended for Reuse Test Site',
         ]);
         WikiProfile::create([
-            'wiki_id' => $incompleteProfileWiki->id,
-            'purpose' => 'other',
+            'wiki_id' => $wiki->id,
+            'purpose' => 'test_drive',
             'temporality' => 'temporary',
-            'audience' => 'other',
         ]);
 
         $controller = new PublicWikiController;
         $request = new Request;
         $resourceCollection = $controller->index($request);
 
-        $resource = $resourceCollection->firstWhere('id', $incompleteProfileWiki->id);
+        $resource = $resourceCollection->firstWhere('id', $wiki->id);
 
         $this->assertNotNull($resource);
         $this->assertFalse($resource->toArray($request)['reuse_prototype']);

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -63,4 +63,42 @@ class PublicWikiControllerTest extends TestCase {
         $this->assertSame(1, $wikiProfileQueryCount);
         $this->assertTrue($resourceCollection->first()->relationLoaded('wikiLatestProfile'));
     }
+
+    public function testIndexReturnsFalseWhenWikiHasNoLatestProfile(): void {
+        $wikiWithoutProfile = Wiki::factory()->create([
+            'domain' => 'no-profile.wikibase.cloud',
+            'sitename' => 'No Profile Test Site',
+        ]);
+
+        $controller = new PublicWikiController;
+        $request = new Request;
+        $resourceCollection = $controller->index($request);
+
+        $resource = $resourceCollection->firstWhere('id', $wikiWithoutProfile->id);
+
+        $this->assertNotNull($resource);
+        $this->assertFalse($resource->toArray($request)['reuse_prototype']);
+    }
+
+    public function testIndexReturnsFalseWhenWikiLatestProfileDoesNotMatchReusePrototype(): void {
+        $incompleteProfileWiki = Wiki::factory()->create([
+            'domain' => 'incomplete-profile.wikibase.cloud',
+            'sitename' => 'Incomplete Profile Test Site',
+        ]);
+        WikiProfile::create([
+            'wiki_id' => $incompleteProfileWiki->id,
+            'purpose' => 'other',
+            'temporality' => 'temporary',
+            'audience' => 'other',
+        ]);
+
+        $controller = new PublicWikiController;
+        $request = new Request;
+        $resourceCollection = $controller->index($request);
+
+        $resource = $resourceCollection->firstWhere('id', $incompleteProfileWiki->id);
+
+        $this->assertNotNull($resource);
+        $this->assertFalse($resource->toArray($request)['reuse_prototype']);
+    }
 }

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Http\Controllers;
+
+use App\Http\Controllers\PublicWikiController;
+use App\Http\Resources\PublicWikiResource;
+use App\Wiki;
+use App\WikiProfile;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class PublicWikiControllerTest extends TestCase {
+    use DatabaseTransactions;
+
+    public function testShowEagerLoadsWikiLatestProfileForResource(): void {
+        $wiki = Wiki::factory()->create([
+            'domain' => 'controller-test.wikibase.cloud',
+            'sitename' => 'controller-test',
+        ]);
+
+        WikiProfile::create([
+            'wiki_id' => $wiki->id,
+            'purpose' => 'data_hub',
+            'temporality' => 'permanent',
+            'audience' => 'wide',
+        ]);
+
+        $controller = new PublicWikiController;
+        $resource = $controller->show($wiki->id);
+
+        $this->assertInstanceOf(PublicWikiResource::class, $resource);
+        $this->assertSame(true, $resource->toArray(request())['reuse_prototype']);
+    }
+}

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -35,9 +35,7 @@ class PublicWikiControllerTest extends TestCase {
     }
 
     public function testIndexEagerLoadsWikiLatestProfileOnceForCollection(): void {
-        $n = rand(3, 100);
-        echo $n;
-        for ($i = 1; $i <= $n; $i++) {
+        for ($i = 1; $i <= rand(3, 100); $i++) {
             $wiki = Wiki::factory()->create([
                 'domain' => 'index-eager-load-test-' . $i . '.wikibase.cloud',
                 'sitename' => 'Index Eager Load Test Site ' . $i,

--- a/tests/Routes/Wiki/PublicWikiTest.php
+++ b/tests/Routes/Wiki/PublicWikiTest.php
@@ -326,7 +326,7 @@ class PublicWikiTest extends TestCase {
             ->assertJsonPath('data.2.domain', 'no-profile.wikibase.cloud')
             ->assertJsonPath('data.2.reuse_prototype', false);
 
-        $this->json('GET', 'reusePrototype/' . $reusableWiki->id)
+        $this->json('GET', $this->route . '/' . $reusableWiki->id)
             ->assertStatus(200)
             ->assertJsonPath('data.reuse_prototype', true);
     }

--- a/tests/Routes/Wiki/PublicWikiTest.php
+++ b/tests/Routes/Wiki/PublicWikiTest.php
@@ -325,9 +325,5 @@ class PublicWikiTest extends TestCase {
             ->assertJsonPath('data.1.reuse_prototype', false)
             ->assertJsonPath('data.2.domain', 'no-profile.wikibase.cloud')
             ->assertJsonPath('data.2.reuse_prototype', false);
-
-        $this->json('GET', $this->route . '/' . $reusableWiki->id)
-            ->assertStatus(200)
-            ->assertJsonPath('data.reuse_prototype', true);
     }
 }

--- a/tests/Routes/Wiki/PublicWikiTest.php
+++ b/tests/Routes/Wiki/PublicWikiTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Routes\Wiki;
 
 use App\Wiki;
+use App\WikiProfile;
 use App\WikiSetting;
 use App\WikiSiteStats;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
@@ -18,12 +19,14 @@ class PublicWikiTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
         Wiki::query()->delete();
+        WikiProfile::query()->delete();
         WikiSiteStats::query()->delete();
         WikiSetting::query()->delete();
     }
 
     protected function tearDown(): void {
         Wiki::query()->delete();
+        WikiProfile::query()->delete();
         WikiSiteStats::query()->delete();
         WikiSetting::query()->delete();
         parent::tearDown();
@@ -278,5 +281,49 @@ class PublicWikiTest extends TestCase {
                 'https://storage.googleapis.com/wikibase-cloud/foo.bar.png'
             )
             ->assertJsonPath('data.1.logo_url', null);
+    }
+
+    public function testReusePrototype() {
+        $reusableWiki = Wiki::factory()->create([
+            'domain' => 'reusable.wikibase.cloud', 'sitename' => 'asite',
+        ]);
+        WikiSiteStats::factory()->create([
+            'wiki_id' => $reusableWiki->id,
+        ]);
+        WikiProfile::create([
+            'wiki_id' => $reusableWiki->id,
+            'purpose' => 'data_hub',
+            'temporality' => 'permanent',
+            'audience' => 'wide',
+        ]);
+
+        $nonReusableWiki = Wiki::factory()->create([
+            'domain' => 'non-reusable.wikibase.cloud', 'sitename' => 'bsite',
+        ]);
+        WikiSiteStats::factory()->create([
+            'wiki_id' => $nonReusableWiki->id,
+        ]);
+        WikiProfile::create([
+            'wiki_id' => $nonReusableWiki->id,
+            'purpose' => 'other',
+            'temporality' => 'other',
+            'audience' => 'other',
+        ]);
+
+        $noProfileWiki = Wiki::factory()->create([
+            'domain' => 'no-profile.wikibase.cloud', 'sitename' => 'csite',
+        ]);
+        WikiSiteStats::factory()->create([
+            'wiki_id' => $noProfileWiki->id,
+        ]);
+
+        $this->json('GET', $this->route)
+            ->assertStatus(200)
+            ->assertJsonPath('data.0.domain', 'reusable.wikibase.cloud')
+            ->assertJsonPath('data.0.reuse_prototype', true)
+            ->assertJsonPath('data.1.domain', 'non-reusable.wikibase.cloud')
+            ->assertJsonPath('data.1.reuse_prototype', false)
+            ->assertJsonPath('data.2.domain', 'no-profile.wikibase.cloud')
+            ->assertJsonPath('data.2.reuse_prototype', null);
     }
 }

--- a/tests/Routes/Wiki/PublicWikiTest.php
+++ b/tests/Routes/Wiki/PublicWikiTest.php
@@ -325,5 +325,9 @@ class PublicWikiTest extends TestCase {
             ->assertJsonPath('data.1.reuse_prototype', false)
             ->assertJsonPath('data.2.domain', 'no-profile.wikibase.cloud')
             ->assertJsonPath('data.2.reuse_prototype', null);
+
+        $this->json('GET', 'reusePrototype/' . $reusableWiki->id)
+            ->assertStatus(200)
+            ->assertJsonPath('data.reuse_prototype', true);
     }
 }

--- a/tests/Routes/Wiki/PublicWikiTest.php
+++ b/tests/Routes/Wiki/PublicWikiTest.php
@@ -324,7 +324,7 @@ class PublicWikiTest extends TestCase {
             ->assertJsonPath('data.1.domain', 'non-reusable.wikibase.cloud')
             ->assertJsonPath('data.1.reuse_prototype', false)
             ->assertJsonPath('data.2.domain', 'no-profile.wikibase.cloud')
-            ->assertJsonPath('data.2.reuse_prototype', null);
+            ->assertJsonPath('data.2.reuse_prototype', false);
 
         $this->json('GET', 'reusePrototype/' . $reusableWiki->id)
             ->assertStatus(200)

--- a/tests/Routes/Wiki/PublicWikiTest.php
+++ b/tests/Routes/Wiki/PublicWikiTest.php
@@ -317,7 +317,7 @@ class PublicWikiTest extends TestCase {
             'wiki_id' => $noProfileWiki->id,
         ]);
 
-        $this->json('GET', $this->route)
+        $this->json('GET', 'reusePrototype')
             ->assertStatus(200)
             ->assertJsonPath('data.0.domain', 'reusable.wikibase.cloud')
             ->assertJsonPath('data.0.reuse_prototype', true)


### PR DESCRIPTION
- add `reuse_prototype` field to `PublicWikiResource`
- add a dedicated `/reusePrototype` endpoint to decouple the prototype from our internal `/wiki` endpoint
- add unit tests for `PublicWikiController` behavior including test to ensure the additional `reuse_prototype` field doesn't cause an N+1 query issue
- add e2e test for `/reusePrototype` endpoint

Bug: T421877