### PR TITLE
Allow dependabot composer "direct" updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 50
+  allow:
+   - dependency-type: direct
   ignore:
   - dependency-name: lcobucci/jwt
     versions:


### PR DESCRIPTION
We hope that this includes all production and dev dependencies but we need to confirm by doing because the documentation isn't clear.