### PR TITLE
dependabot remove composer allow section

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,9 +10,6 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 50
-  allow:
-   - dependency-type: direct
-   - dependency-type: development
   ignore:
   - dependency-name: lcobucci/jwt
     versions:


### PR DESCRIPTION
It seems that "direct" and "development" `dependency-type` are always included.

We can only conclude that the missing development dependency updates either do not resolve at all, or the latest version of them does not resolve now.

We had previously defined a limit of 10 open PRs at a time.

For example, a compatible update from `1.0` to `1.1` will not be made if the PR limit has been reached. Later, when a new `1.2` release is made, it may be incompatible with other packages. Now no PR is made because dependabot doesn't check all historic versions (in this case `1.1`).