### PR TITLE
Add test class for Authenticate middleware

### DIFF
--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -18,12 +18,7 @@ class AuthenticateTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
 
-        Artisan::call('passport:keys', ['--force' => true]);
-        Artisan::call('passport:client', [
-            '--personal' => true,
-            '--name' => 'Authenticate middleware test',
-            '--no-interaction' => true,
-        ]);
+        Artisan::call('passport:install', ['--no-interaction' => true]);
 
         // Register new test route with Authenticate middleware. This also tests the config in Kernel.php and auth.php.
         Route::middleware('auth:api')->get(self::ENDPOINT, function (Request $request) {
@@ -49,6 +44,14 @@ class AuthenticateTest extends TestCase {
             ->assertJson(['email' => $user->email]);
     }
 
+    public function testFailsUsingInvalidPassportTokenFromCookie(): void {
+        $this->withCredentials()
+            ->withUnencryptedCookie(Config::get('auth.cookies.key'), 'this is an invalid token')
+            ->json('GET', self::ENDPOINT)
+            ->assertStatus(401)
+            ->assertJson(['error' => 'Unauthenticated.']);
+    }
+
     public function testAuthenticatesUsingPassportTokenFromAuthorizationHeader(): void {
         $user = User::factory()->create();
 
@@ -57,6 +60,14 @@ class AuthenticateTest extends TestCase {
             ->json('GET', self::ENDPOINT)
             ->assertStatus(200)
             ->assertJson(['email' => $user->email]);
+    }
+
+    public function testFailsUsingInvalidPassportTokenFromAuthorizationHeader(): void {
+        $this->withCredentials()
+            ->withHeader('Authorization', 'Bearer ' . 'this is an invalid token')
+            ->json('GET', self::ENDPOINT)
+            ->assertStatus(401)
+            ->assertJson(['error' => 'Unauthenticated.']);
     }
 
     private function issueTokenFor(User $user): string {

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -49,6 +49,16 @@ class AuthenticateTest extends TestCase {
             ->assertJson(['email' => $user->email]);
     }
 
+    public function testAuthenticatesUsingPassportTokenFromAuthorizationHeader(): void {
+        $user = User::factory()->create();
+
+        $this->withCredentials()
+            ->withHeader('Authorization', 'Bearer ' . $this->issueTokenFor($user))
+            ->json('GET', self::ENDPOINT)
+            ->assertStatus(200)
+            ->assertJson(['email' => $user->email]);
+    }
+
     private function issueTokenFor(User $user): string {
         return $user->createToken('authenticate-middleware-test')->accessToken;
     }

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -25,6 +25,7 @@ class AuthenticateTest extends TestCase {
             '--no-interaction' => true,
         ]);
 
+        // Register new test route with Authenticate middleware. This also tests the config in Kernel.php and auth.php.
         Route::middleware('auth:api')->get(self::ENDPOINT, function (Request $request) {
             return response()->json([
                 'email' => $request->user()->email,

--- a/tests/Middleware/AuthenticateTest.php
+++ b/tests/Middleware/AuthenticateTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Tests\Middleware;
+
+use App\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class AuthenticateTest extends TestCase {
+    use RefreshDatabase;
+
+    private const ENDPOINT = '/api/test/authenticate-middleware';
+
+    protected function setUp(): void {
+        parent::setUp();
+
+        Artisan::call('passport:keys', ['--force' => true]);
+        Artisan::call('passport:client', [
+            '--personal' => true,
+            '--name' => 'Authenticate middleware test',
+            '--no-interaction' => true,
+        ]);
+
+        Route::middleware('auth:api')->get(self::ENDPOINT, function (Request $request) {
+            return response()->json([
+                'email' => $request->user()->email,
+            ]);
+        });
+    }
+
+    public function testReturnsCustomJsonWhenUnauthenticated(): void {
+        $this->json('GET', self::ENDPOINT)
+            ->assertStatus(401)
+            ->assertJson(['error' => 'Unauthenticated.']);
+    }
+
+    public function testAuthenticatesUsingPassportTokenFromCookie(): void {
+        $user = User::factory()->create();
+
+        $this->withCredentials()
+            ->withUnencryptedCookie(Config::get('auth.cookies.key'), $this->issueTokenFor($user))
+            ->json('GET', self::ENDPOINT)
+            ->assertStatus(200)
+            ->assertJson(['email' => $user->email]);
+    }
+
+    private function issueTokenFor(User $user): string {
+        return $user->createToken('authenticate-middleware-test')->accessToken;
+    }
+}


### PR DESCRIPTION
Add missing test for Authenticate middleware to ensure nothing is broken when we update packages.

Bug: T424471