### PR TITLE
Remove abandoned and unused `php-http/*` dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,6 @@
         "maclof/kubernetes-client": "^0.31.0",
         "mxl/laravel-job": "^1.5",
         "php-http/guzzle7-adapter": "^1.0",
-        "php-http/message": "^1.16",
-        "php-http/message-factory": "^1.1",
         "predis/predis": "^3.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -5436,61 +5436,6 @@
             "time": "2024-10-02T11:34:13+00:00"
         },
         {
-            "name": "php-http/message-factory",
-            "version": "1.1.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-http/message-factory.git",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message-factory/zipball/4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "reference": "4d8778e1c7d405cbb471574821c1ff5b68cc8f57",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Márk Sági-Kazár",
-                    "email": "mark.sagikazar@gmail.com"
-                }
-            ],
-            "description": "Factory interfaces for PSR-7 HTTP Message",
-            "homepage": "http://php-http.org",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "stream",
-                "uri"
-            ],
-            "support": {
-                "issues": "https://github.com/php-http/message-factory/issues",
-                "source": "https://github.com/php-http/message-factory/tree/1.1.0"
-            },
-            "abandoned": "psr/http-factory",
-            "time": "2023-04-14T14:16:17+00:00"
-        },
-        {
             "name": "php-http/promise",
             "version": "1.3.1",
             "source": {


### PR DESCRIPTION
`php-http/message-factory` has been replaced by `psr/http-factory` and is now abandoned. 
`php-http/message-factory` was added in 8d37f7a as part of updating to PHP 8.1. 
`php-http/message-factory` is not currently being used by our code.
`php-http/message` is not currently being used by our code.

Remove `php-http/message-factory` and `php-http/message` as a root dependency with:
```
docker run --rm -it -v $PWD:/app -u $(id -u):$(id -g) composer:2.9.2 --ignore-platform-req=ext-pcntl remove php-http/message-factory php-http/message
```

Bug: T425685