### PR TITLE
test: only use mariadb 10.5.15

### DIFF
--- a/.github/workflows/composer.test.yml
+++ b/.github/workflows/composer.test.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        databaseImageName: [ 'mariadb:10.5.9', 'mariadb:10.5.12' ]
+        databaseImageName: [ 'mariadb:10.5.15' ]
 
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We use 10.5.15 in production; we should therefore target this for our tests not two older versions