### PR TITLE
Don't mount `words/` dir in `docker-compose.yml`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ services:
       - ./:/var/www/html
       - ./start.sh:/usr/local/bin/start
       - api-storage:/var/www/html/storage/
-      - ./words:/words
       - ./docker.my.cnf:/etc/mysql/conf.d/custom.mysql.cnf
     ports:
       - 8082:80


### PR DESCRIPTION
The `words/` dir was moved to a `app/Http/Controllers/Sandbox/words` file in f7d7a74