### PR TITLE
Adjust API date handling for Carbon 3 behavior changes

### DIFF
--- a/app/Helper/MWTimestampHelper.php
+++ b/app/Helper/MWTimestampHelper.php
@@ -9,14 +9,15 @@
 namespace App\Helper;
 
 use Carbon\CarbonImmutable;
+use Carbon\Exceptions\InvalidFormatException;
 
 class MWTimestampHelper {
     private const MWTimestampFormat = 'YmdHis';
 
     public static function getCarbonFromMWTimestamp(string $MWTimestamp): CarbonImmutable {
         $carbon = CarbonImmutable::createFromFormat(self::MWTimestampFormat, $MWTimestamp);
-        if ($carbon === false) {
-            throw new \Exception('Unable to create Carbon object');
+        if ($carbon === null) {
+            throw new InvalidFormatException('Unable to create Carbon object');
         }
 
         return $carbon;

--- a/app/Http/Controllers/ConversionMetricController.php
+++ b/app/Http/Controllers/ConversionMetricController.php
@@ -31,12 +31,17 @@ class ConversionMetricController extends Controller {
             }
             $time_before_wiki_abandoned_days = null;
             $time_to_engage_days = null;
+            $daysSinceLastEdit = null;
 
-            if (!is_null($wikiLastEditedTime) && ($wikiLastEditedTime->diffInDays($current_date, false) >= 90)) {
-                $time_before_wiki_abandoned_days = $wiki->created_at->diffInDays($wikiLastEditedTime, false);
+            if ($wikiLastEditedTime !== null) {
+                $daysSinceLastEdit = (int) $wikiLastEditedTime->diffInDays($current_date, false);
+            }
+
+            if ($daysSinceLastEdit !== null && $daysSinceLastEdit >= 90) {
+                $time_before_wiki_abandoned_days = (int) $wiki->created_at->diffInDays($wikiLastEditedTime, false);
             }
             if ($wikiFirstEditedTime !== null) {
-                $time_to_engage_days = $wiki->created_at->diffInDays($wikiFirstEditedTime, false);
+                $time_to_engage_days = (int) $wiki->created_at->diffInDays($wikiFirstEditedTime, false);
             }
             $wiki_number_of_editors = $wiki->wikiSiteStats()->first()['activeusers'] ?? null;
 

--- a/app/Jobs/PlatformStatsSummaryJob.php
+++ b/app/Jobs/PlatformStatsSummaryJob.php
@@ -132,7 +132,7 @@ class PlatformStatsSummaryJob extends Job {
             // is it edited in the last 90 days?
             if (!is_null($stats['lastEdit'])) {
                 $lastTimestamp = MWTimestampHelper::getCarbonFromMWTimestamp(intval($stats['lastEdit']));
-                $diff = $lastTimestamp->diffInSeconds($currentTime);
+                $diff = (int) $lastTimestamp->diffInSeconds($currentTime, true);
 
                 if ($diff <= $this->inactiveThreshold) {
                     $editedLast90DaysWikis[] = $wiki;

--- a/app/Jobs/SendEmptyWikiNotificationsJob.php
+++ b/app/Jobs/SendEmptyWikiNotificationsJob.php
@@ -34,7 +34,7 @@ class SendEmptyWikiNotificationsJob extends Job implements ShouldBeUnique {
         $emptyDaysThreshold = config('wbstack.wiki_empty_notification_threshold');
         $createdAt = $wiki->created_at;
         $now = CarbonImmutable::now();
-        $emptyWikiDays = $createdAt->diffInDays($now);
+        $emptyWikiDays = (int) $createdAt->diffInDays($now, true);
 
         $firstEdited = $wiki->wikiLifecycleEvents->first_edited;
 


### PR DESCRIPTION
- Preserve expected integer and signed/absolute diff behavior.
- Update `createFromFormat` handling for Carbon 3's null return value.

Bug: T426592