### PR TITLE
Fix data providers in ProfileValidatorTest

### DIFF
--- a/tests/Helper/ProfileValidatorTest.php
+++ b/tests/Helper/ProfileValidatorTest.php
@@ -24,46 +24,46 @@ class ProfileValidatorTest extends TestCase {
         $this->assertFalse($validator->passes());
     }
 
-    public static function validProfileProvider() {
-        return [
-            ['boring profile with no other' => [
-                'purpose' => 'data_hub',
-                'audience' => 'narrow',
-                'temporality' => 'permanent',
-            ]],
-            ['with other values' => [
-                'purpose' => 'data_hub',
-                'audience' => 'other',
-                'audience_other' => 'my cat',
-                'temporality' => 'other',
-                'temporality_other' => 'only in the past',
-            ]],
-        ];
+    public static function validProfileProvider(): iterable {
+        yield 'boring profile with no other' => [[
+            'purpose' => 'data_hub',
+            'audience' => 'narrow',
+            'temporality' => 'permanent',
+        ]];
+
+        yield 'with other values' => [[
+            'purpose' => 'data_hub',
+            'audience' => 'other',
+            'audience_other' => 'my cat',
+            'temporality' => 'other',
+            'temporality_other' => 'only in the past',
+        ]];
     }
 
-    public static function invalidProfileProvider() {
-        return [
-            ['missing other keys' => [
-                'purpose' => 'data_hub',
-                'audience' => 'narrow',
-                'temporality' => 'other',
-            ]],
-            ['audience is empty string' => [
-                'purpose' => 'data_hub',
-                'audience' => '',
-                'temporality' => 'other',
-            ]],
-            ['audience key present when purpose not data_hub' => [
-                'purpose' => 'data_lab',
-                'audience' => 'narrow',
-                'temporality' => 'permanent',
-            ]],
-            ['other keys when there should not be' => [
-                'purpose' => 'data_hub',
-                'purpose_other' => 'asdfasdf',
-                'audience' => 'narrow',
-                'temporality' => 'permanent',
-            ]],
-        ];
+    public static function invalidProfileProvider(): iterable {
+        yield 'missing other keys' => [[
+            'purpose' => 'data_hub',
+            'audience' => 'narrow',
+            'temporality' => 'other',
+        ]];
+
+        yield 'audience is empty string' => [[
+            'purpose' => 'data_hub',
+            'audience' => '',
+            'temporality' => 'other',
+        ]];
+
+        yield 'audience key present when purpose not data_hub' => [[
+            'purpose' => 'data_lab',
+            'audience' => 'narrow',
+            'temporality' => 'permanent',
+        ]];
+
+        yield 'other keys when there should not be' => [[
+            'purpose' => 'data_hub',
+            'purpose_other' => 'asdfasdf',
+            'audience' => 'narrow',
+            'temporality' => 'permanent',
+        ]];
     }
 }


### PR DESCRIPTION
The data providers in `ProfileValidatorTest` where returning an improperly constructed array causing the data set name to b treated as a named parameter (which obviously didn't exist). This was tolerated but deprecated in PHPUnit 10.x. It will not be supported in PHPUnit 11.x.

Return generator from data providers for less array nesting and easier reading.

Bug: T428034