### PR TITLE
lint: require parentheses when instantiating a new class

### DIFF
--- a/app/Console/Commands/Invitation/CreateBulk.php
+++ b/app/Console/Commands/Invitation/CreateBulk.php
@@ -18,7 +18,7 @@ class CreateBulk extends Command {
      */
     public function handle() {
         $numCodes = trim($this->argument('numCodes'));
-        $helper = new InviteHelper;
+        $helper = new InviteHelper();
 
         for ($i = 0; $i < $numCodes; $i++) {
             $code = $helper->generate();

--- a/app/Console/Commands/ScheduleStatsUpdates.php
+++ b/app/Console/Commands/ScheduleStatsUpdates.php
@@ -52,7 +52,7 @@ class ScheduleStatsUpdates extends Command {
         Bus::batch($siteStatsUpdateJobs)
             ->allowFailures()
             ->finally(function (): void {
-                dispatch(new PlatformStatsSummaryJob);
+                dispatch(new PlatformStatsSummaryJob());
             })->dispatch();
 
         return 0;

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,17 +33,17 @@ class Kernel extends ConsoleKernel {
         $schedule->job(new ProvisionQueryserviceNamespaceJob(null, 10))->everyMinute()->withoutOverlapping();
 
         // Slowly cleanup some tables
-        $schedule->job(new ExpireOldUserVerificationTokensJob)->hourly()->withoutOverlapping();
-        $schedule->job(new PruneEventPageUpdatesTable)->everyFifteenMinutes()->withoutOverlapping();
-        $schedule->job(new PruneQueryserviceBatchesTable)->everyFifteenMinutes()->withoutOverlapping();
-        $schedule->job(new CreateQueryserviceBatchesJob)->everyMinute()->withoutOverlapping();
-        $schedule->job(new RequeuePendingQsBatchesJob)->everyFifteenMinutes()->withoutOverlapping();
-        $schedule->job(new FailStalledEntityImportsJob)->hourly();
+        $schedule->job(new ExpireOldUserVerificationTokensJob())->hourly()->withoutOverlapping();
+        $schedule->job(new PruneEventPageUpdatesTable())->everyFifteenMinutes()->withoutOverlapping();
+        $schedule->job(new PruneQueryserviceBatchesTable())->everyFifteenMinutes()->withoutOverlapping();
+        $schedule->job(new CreateQueryserviceBatchesJob())->everyMinute()->withoutOverlapping();
+        $schedule->job(new RequeuePendingQsBatchesJob())->everyFifteenMinutes()->withoutOverlapping();
+        $schedule->job(new FailStalledEntityImportsJob())->hourly();
 
         // Sandbox
         // TODO this should maybe only be run when sandbox as a whole is loaded?
         // TODO instead of using LOAD ROUTES, we should just have different modes?
-        $schedule->job(new SandboxCleanupJob)->everyFifteenMinutes()->withoutOverlapping();
+        $schedule->job(new SandboxCleanupJob())->everyFifteenMinutes()->withoutOverlapping();
 
         // Schedule site stat updates for each wiki and platform-summary
         $schedule->command('schedule:stats')->dailyAt('7:00');
@@ -51,15 +51,15 @@ class Kernel extends ConsoleKernel {
         // https://laravel.com/docs/10.x/upgrade#redis-cache-tags
         $schedule->command('cache:prune-stale-tags')->hourly()->withoutOverlapping();
 
-        $schedule->job(new PollForMediaWikiJobsJob)->everyFifteenMinutes()->withoutOverlapping();
+        $schedule->job(new PollForMediaWikiJobsJob())->everyFifteenMinutes()->withoutOverlapping();
 
-        $schedule->job(new UpdateWikiSiteStatsJob)->dailyAt('19:00');
+        $schedule->job(new UpdateWikiSiteStatsJob())->dailyAt('19:00');
 
-        $schedule->job(new SendEmptyWikiNotificationsJob)->dailyAt('21:00');
+        $schedule->job(new SendEmptyWikiNotificationsJob())->dailyAt('21:00');
 
-        $schedule->job(new UpdateWikiDailyMetricJob)->dailyAt('23:00');
+        $schedule->job(new UpdateWikiDailyMetricJob())->dailyAt('23:00');
 
-        $schedule->job(new UpdateQueryserviceAllowList)->weeklyOn(Schedule::MONDAY, '01:00');
+        $schedule->job(new UpdateQueryserviceAllowList())->weeklyOn(Schedule::MONDAY, '01:00');
 
     }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -22,7 +22,7 @@ class Handler extends ExceptionHandler {
      */
     public function register(): void {
         $this->reportable(function (Throwable $e): void {
-            (new ErrorReporting)->report($e);
+            (new ErrorReporting())->report($e);
         });
     }
 }

--- a/app/Http/Controllers/Backend/MediaWikiHostsController.php
+++ b/app/Http/Controllers/Backend/MediaWikiHostsController.php
@@ -11,7 +11,7 @@ use Illuminate\Http\Request;
 
 class MediaWikiHostsController extends Controller {
     public function getWikiHostsForDomain(Request $request): JsonResponse {
-        $mediawikiHostResolver = new MediaWikiHostResolver;
+        $mediawikiHostResolver = new MediaWikiHostResolver();
         $domain = $request->query('domain');
         try {
             $hosts = $mediawikiHostResolver->getHostsForDomain($domain);

--- a/app/Http/Controllers/ComplaintController.php
+++ b/app/Http/Controllers/ComplaintController.php
@@ -40,7 +40,7 @@ class ComplaintController extends Controller {
 
         $validated = $validator->safe();
 
-        $complaintRecord = new ComplaintRecord;
+        $complaintRecord = new ComplaintRecord();
         $complaintRecord->name = $validated['name'];
         $complaintRecord->mail_address = $validated['email'];
         $complaintRecord->reason = $validated['message'];

--- a/app/Http/Controllers/Sandbox/SandboxController.php
+++ b/app/Http/Controllers/Sandbox/SandboxController.php
@@ -114,7 +114,7 @@ class SandboxController extends Controller {
     }
 
     private function generateDomain(): string {
-        $generator = new HumanPasswordGenerator;
+        $generator = new HumanPasswordGenerator();
 
         $generator
             ->setWordList(__DIR__ . '/words')

--- a/app/Http/Controllers/WikiProfileController.php
+++ b/app/Http/Controllers/WikiProfileController.php
@@ -18,7 +18,7 @@ class WikiProfileController extends Controller {
     public function create(Request $request): JsonResponse {
         $wiki = $request->attributes->get('wiki');
         $validatedInput = $request->validate([
-            'profile' => ['required', 'json', new NonEmptyJsonRule],
+            'profile' => ['required', 'json', new NonEmptyJsonRule()],
         ]);
 
         $rawProfile = json_decode($validatedInput['profile'], true);

--- a/app/Http/Controllers/WikiSettingController.php
+++ b/app/Http/Controllers/WikiSettingController.php
@@ -23,9 +23,9 @@ class WikiSettingController extends Controller {
             'wwWikibaseStringLengthMonolingualText' => ['required', 'integer', 'between:400,2500'],
             'wwWikibaseStringLengthMultilang' => ['required', 'integer', 'between:250,2500'],
             'wikibaseFedPropsEnable' => ['required', 'boolean'],
-            'wikibaseManifestEquivEntities' => ['required', 'json', new SettingWikibaseManifestEquivEntities],
+            'wikibaseManifestEquivEntities' => ['required', 'json', new SettingWikibaseManifestEquivEntities()],
             'wwUseQuestyCaptcha' => ['required', 'boolean'],
-            'wwCaptchaQuestions' => ['required', 'json', new SettingCaptchaQuestions],
+            'wwCaptchaQuestions' => ['required', 'json', new SettingCaptchaQuestions()],
         ];
     }
 

--- a/app/Jobs/UpdateWikiDailyMetricJob.php
+++ b/app/Jobs/UpdateWikiDailyMetricJob.php
@@ -20,7 +20,7 @@ class UpdateWikiDailyMetricJob extends Job implements ShouldBeUnique {
     public function handle(): void {
         $wikis = Wiki::withTrashed()->get();
         foreach ($wikis as $wiki) {
-            (new WikiMetrics)->saveMetrics($wiki);
+            (new WikiMetrics())->saveMetrics($wiki);
         }
     }
 }

--- a/app/Notifications/ComplaintNotification.php
+++ b/app/Notifications/ComplaintNotification.php
@@ -66,7 +66,7 @@ class ComplaintNotification extends Notification {
         $mailFrom = config('app.complaint-mail-sender');
         $mailSubject = config('app.name') . ': Report of Illegal Content';
 
-        return (new MailMessage)
+        return (new MailMessage())
             ->from($mailFrom)
             ->subject($mailSubject)
             ->line(Lang::get('A message via the wikibase.cloud form for reporting illegal content has been submitted.'))

--- a/app/Notifications/ComplaintNotificationExternal.php
+++ b/app/Notifications/ComplaintNotificationExternal.php
@@ -25,7 +25,7 @@ class ComplaintNotificationExternal extends ComplaintNotification {
         $mailFrom = config('app.complaint-mail-sender');
         $mailSubject = config('app.name') . ': Report of Illegal Content';
 
-        return (new MailMessage)
+        return (new MailMessage())
             ->from($mailFrom)
             ->subject($mailSubject)
             ->line(Lang::get('Your message via the wikibase.cloud form for reporting illegal content has been submitted.'))

--- a/app/Notifications/ContactNotification.php
+++ b/app/Notifications/ContactNotification.php
@@ -57,7 +57,7 @@ class ContactNotification extends Notification {
         $mailFrom = str_replace('<subject>', $this->subject, config('app.contact-mail-sender'));
         $mailSubject = config('app.name') . Lang::get(' contact form message: ') . $subject;
 
-        return (new MailMessage)
+        return (new MailMessage())
             ->from($mailFrom)
             ->subject($mailSubject)
             ->line(Lang::get('A message via the wikibase.cloud contact form has been submitted.'))

--- a/app/Notifications/EmailReverificationNotification.php
+++ b/app/Notifications/EmailReverificationNotification.php
@@ -58,7 +58,7 @@ class EmailReverificationNotification extends Notification {
 
         $verifyEmailLink = config('wbstack.ui_url') . '/emailVerification/' . $this->token;
 
-        return (new MailMessage)
+        return (new MailMessage())
             ->subject(Lang::get('Please verify your email'))
             ->line(Lang::get('Someone, probably you, has requested another link to verify the email associated with your Wikibase.cloud account. You’re just one step away from taking advantage of all that the platform has to offer. To complete your registration, verify your email address by clicking below.'))
             ->action(Lang::get('Verify Email'), $verifyEmailLink)

--- a/app/Notifications/EmptyWikiNotification.php
+++ b/app/Notifications/EmptyWikiNotification.php
@@ -44,7 +44,7 @@ class EmptyWikiNotification extends Notification {
     public function toMail($notifiable) {
         $days = intval(config('wbstack.wiki_empty_notification_threshold'));
 
-        return (new MailMessage)
+        return (new MailMessage())
             ->from('noreply@wikibase.cloud', 'Wikibase Cloud')
             ->subject(Lang::get('Need some help with your Wikibase?'))
             ->line(Lang::get('Thanks for creating a Wikibase instance on Wikibase Cloud! That was at least ' . $days . ' days ago. We couldn’t help but notice that your Wikibase instance `' . $this->sitename . '` remains empty, so we’re checking in to see if we can help.'))

--- a/app/Notifications/ResetPasswordNotification.php
+++ b/app/Notifications/ResetPasswordNotification.php
@@ -59,7 +59,7 @@ class ResetPasswordNotification extends Notification {
         $queryPart = "?token=$this->token&email={$encodedEmail}";
         $resetPasswordLink = config('wbstack.ui_url') . '/reset-password' . $queryPart;
 
-        return (new MailMessage)
+        return (new MailMessage())
             ->subject(Lang::get('Please reset your password'))
             ->line(Lang::get('You are receiving this email because we received a password reset request for your account.'))
             ->action(Lang::get('Reset Password'), $resetPasswordLink)

--- a/app/Notifications/UserCreationNotification.php
+++ b/app/Notifications/UserCreationNotification.php
@@ -57,7 +57,7 @@ class UserCreationNotification extends Notification {
 
         $verifyEmailLink = config('wbstack.ui_url') . '/emailVerification/' . $this->token;
 
-        return (new MailMessage)
+        return (new MailMessage())
             ->subject(Lang::get('Action Needed: Please verify your email'))
             ->line(Lang::get('Welcome to Wikibase.cloud! You’re just one step away from taking advantage of all that the platform has to offer. To complete your registration, verify your email address by clicking below.'))
             ->action(Lang::get('Verify Email'), $verifyEmailLink)

--- a/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_06_01_000001_create_oauth_auth_codes_table.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_06_01_000002_create_oauth_access_tokens_table.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_06_01_000003_create_oauth_refresh_tokens_table.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
+++ b/database/migrations/2016_06_01_000004_create_oauth_clients_table.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      */

--- a/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_06_01_000005_create_oauth_personal_access_clients_table.php
@@ -8,7 +8,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-return new class extends Migration {
+return new class() extends Migration {
     /**
      * Run the migrations.
      */

--- a/pint.json
+++ b/pint.json
@@ -14,6 +14,7 @@
     "concat_space": {
       "spacing": "one"
     },
-    "not_operator_with_successor_space": false
+    "not_operator_with_successor_space": false,
+    "new_with_parentheses": true
   }
 }

--- a/tests/Helper/ProfileValidatorTest.php
+++ b/tests/Helper/ProfileValidatorTest.php
@@ -10,7 +10,7 @@ class ProfileValidatorTest extends TestCase {
      * @dataProvider validProfileProvider
      */
     public function testProfileValidatorWorksWithValidProfile($profile): void {
-        $validatorFactory = new ProfileValidator;
+        $validatorFactory = new ProfileValidator();
         $validator = $validatorFactory->getValidator($profile);
         $this->assertTrue($validator->passes());
     }
@@ -19,7 +19,7 @@ class ProfileValidatorTest extends TestCase {
      * @dataProvider invalidProfileProvider
      */
     public function testProfileValidatorWorksWithInvalidProfile($profile): void {
-        $validatorFactory = new ProfileValidator;
+        $validatorFactory = new ProfileValidator();
         $validator = $validatorFactory->getValidator($profile);
         $this->assertFalse($validator->passes());
     }

--- a/tests/Http/Controllers/PublicWikiControllerTest.php
+++ b/tests/Http/Controllers/PublicWikiControllerTest.php
@@ -28,11 +28,11 @@ class PublicWikiControllerTest extends TestCase {
             'audience' => 'wide',
         ]);
 
-        $controller = new PublicWikiController;
+        $controller = new PublicWikiController();
         $resource = $controller->show($wiki->id);
 
         $this->assertInstanceOf(PublicWikiResource::class, $resource);
-        $this->assertSame(true, $resource->toArray(new Request)['reuse_prototype']);
+        $this->assertSame(true, $resource->toArray(new Request())['reuse_prototype']);
     }
 
     public function testIndexReusePrototypeOnlyRequiresOneAdditionalDatabaseQuery(): void {
@@ -57,8 +57,8 @@ class PublicWikiControllerTest extends TestCase {
             }
         });
 
-        $controller = new PublicWikiController;
-        $resourceCollection = $controller->index(new Request);
+        $controller = new PublicWikiController();
+        $resourceCollection = $controller->index(new Request());
 
         $this->assertSame(1, $wikiProfilesQueryCount);
         $this->assertTrue($resourceCollection->first()->relationLoaded('wikiLatestProfile'));
@@ -70,8 +70,8 @@ class PublicWikiControllerTest extends TestCase {
             'sitename' => 'No Profile Test Site',
         ]);
 
-        $controller = new PublicWikiController;
-        $request = new Request;
+        $controller = new PublicWikiController();
+        $request = new Request();
         $resourceCollection = $controller->index($request);
 
         $resource = $resourceCollection->firstWhere('id', $wikiWithoutProfile->id);
@@ -91,8 +91,8 @@ class PublicWikiControllerTest extends TestCase {
             'temporality' => 'temporary',
         ]);
 
-        $controller = new PublicWikiController;
-        $request = new Request;
+        $controller = new PublicWikiController();
+        $request = new Request();
         $resourceCollection = $controller->index($request);
 
         $resource = $resourceCollection->firstWhere('id', $wiki->id);

--- a/tests/Jobs/CreateFirstTermsOfUseVersionJobTest.php
+++ b/tests/Jobs/CreateFirstTermsOfUseVersionJobTest.php
@@ -12,7 +12,7 @@ class CreateFirstTermsOfUseVersionJobTest extends TestCase {
     public function testCreateFirstTermsOfUseVersionJob(): void {
         $this->assertDatabaseCount('tou_versions', 0);
 
-        (new CreateFirstTermsOfUseVersionJob)->handle();
+        (new CreateFirstTermsOfUseVersionJob())->handle();
 
         $this->assertDatabaseHas('tou_versions', [
             'version' => '2022-01-01',

--- a/tests/Jobs/CreateQueryserviceBatchesJobTest.php
+++ b/tests/Jobs/CreateQueryserviceBatchesJobTest.php
@@ -40,7 +40,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase {
 
     public function testEmpty(): void {
         $mockJob = $this->createMock(Job::class);
-        $job = new CreateQueryserviceBatchesJob;
+        $job = new CreateQueryserviceBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');
@@ -64,7 +64,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase {
         EventPageUpdate::factory()->create(['id' => 6, 'wiki_id' => 1, 'namespace' => MediawikiNamespace::item, 'title' => 'Q152']);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new CreateQueryserviceBatchesJob;
+        $job = new CreateQueryserviceBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');
@@ -89,7 +89,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase {
         EventPageUpdate::factory()->create(['id' => 234, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q34']);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new CreateQueryserviceBatchesJob;
+        $job = new CreateQueryserviceBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');
@@ -115,7 +115,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase {
         EventPageUpdate::factory()->create(['id' => 124, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q11']);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new CreateQueryserviceBatchesJob;
+        $job = new CreateQueryserviceBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');
@@ -140,7 +140,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase {
         EventPageUpdate::factory()->create(['id' => 125, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q999']);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new CreateQueryserviceBatchesJob;
+        $job = new CreateQueryserviceBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');
@@ -166,7 +166,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase {
         EventPageUpdate::factory()->create(['id' => 134, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q12']);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new CreateQueryserviceBatchesJob;
+        $job = new CreateQueryserviceBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');
@@ -189,7 +189,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase {
         EventPageUpdate::factory()->create(['id' => 188, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q12']);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new CreateQueryserviceBatchesJob;
+        $job = new CreateQueryserviceBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');
@@ -201,7 +201,7 @@ class CreateQueryserviceBatchesJobTest extends TestCase {
         EventPageUpdate::factory()->create(['id' => 198, 'wiki_id' => 99, 'namespace' => MediawikiNamespace::item, 'title' => 'Q126']);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new CreateQueryserviceBatchesJob;
+        $job = new CreateQueryserviceBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');

--- a/tests/Jobs/DeleteWikiDispatcherJobTest.php
+++ b/tests/Jobs/DeleteWikiDispatcherJobTest.php
@@ -33,7 +33,7 @@ class DeleteWikiDispatcherJobTest extends TestCase {
 
     protected function setUp(): void {
         parent::setUp();
-        Log::swap(new LogFake);
+        Log::swap(new LogFake());
         Storage::fake('static-assets');
         $this->wiki = $this->getWiki();
     }
@@ -67,7 +67,7 @@ class DeleteWikiDispatcherJobTest extends TestCase {
         Bus::fake();
 
         $mockJob = $this->createMock(Job::class);
-        $job = new DeleteWikiDispatcherJob;
+        $job = new DeleteWikiDispatcherJob();
         $job->setJob($mockJob);
         $job->handle();
 
@@ -88,7 +88,7 @@ class DeleteWikiDispatcherJobTest extends TestCase {
         $existingWikiNotTimeYet = $this->getWiki(29);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new DeleteWikiDispatcherJob;
+        $job = new DeleteWikiDispatcherJob();
         $job->setJob($mockJob);
         $job->handle();
 
@@ -130,7 +130,7 @@ class DeleteWikiDispatcherJobTest extends TestCase {
         );
 
         $mockJob = $this->createMock(Job::class);
-        $job = new DeleteWikiDispatcherJob;
+        $job = new DeleteWikiDispatcherJob();
         $job->setJob($mockJob);
         $job->handle();
 
@@ -166,7 +166,7 @@ class DeleteWikiDispatcherJobTest extends TestCase {
         $this->assertNotNull(WikiDb::where(['wiki_id' => $this->wiki->id])->first());
 
         $mockJob = $this->createMock(Job::class);
-        $job = new DeleteWikiDispatcherJob;
+        $job = new DeleteWikiDispatcherJob();
         $job->setJob($mockJob);
         $job->handle();
 

--- a/tests/Jobs/FailStalledEntityImportsJobTest.php
+++ b/tests/Jobs/FailStalledEntityImportsJobTest.php
@@ -47,7 +47,7 @@ class FailStalledEntityImportsJobTest extends TestCase {
         $mockJob = $this->createMock(Job::class);
         $mockJob->expects($this->never())->method('fail');
 
-        $job = new FailStalledEntityImportsJob;
+        $job = new FailStalledEntityImportsJob();
         $job->setJob($mockJob);
         $job->handle();
 

--- a/tests/Jobs/Integration/ElasticSearchIndexDeleteTest.php
+++ b/tests/Jobs/Integration/ElasticSearchIndexDeleteTest.php
@@ -35,7 +35,7 @@ class ElasticSearchIndexDeleteTest extends TestCase {
 
     public function makeRequest($url, $method = 'GET') {
         // create some dummy index
-        $curlRequest = new CurlRequest;
+        $curlRequest = new CurlRequest();
         $curlRequest->setOptions(
             [
                 CURLOPT_URL => $url,

--- a/tests/Jobs/PlatformStatsSummaryJobTest.php
+++ b/tests/Jobs/PlatformStatsSummaryJobTest.php
@@ -89,7 +89,7 @@ class PlatformStatsSummaryJobTest extends TestCase {
         $mockJob = $this->createMock(Job::class);
         $mockJob->expects($this->never())->method('fail');
 
-        $job = new PlatformStatsSummaryJob;
+        $job = new PlatformStatsSummaryJob();
         $job->setJob($mockJob);
 
         $job->handle($manager, $this->mockMwHostResolver);
@@ -100,7 +100,7 @@ class PlatformStatsSummaryJobTest extends TestCase {
         $mockJob = $this->createMock(Job::class);
         $mockJob->expects($this->never())->method('fail');
 
-        $job = new PlatformStatsSummaryJob;
+        $job = new PlatformStatsSummaryJob();
         $job->setJob($mockJob);
 
         $wikis = [
@@ -239,7 +239,7 @@ class PlatformStatsSummaryJobTest extends TestCase {
         $mockJob = $this->createMock(Job::class);
         $mockJob->expects($this->never())->method('fail');
 
-        $job = new PlatformStatsSummaryJob;
+        $job = new PlatformStatsSummaryJob();
         $job->setJob($mockJob);
 
         Wiki::factory()->create([
@@ -297,7 +297,7 @@ class PlatformStatsSummaryJobTest extends TestCase {
             ], 200),
         ]);
 
-        $job = new PlatformStatsSummaryJob;
+        $job = new PlatformStatsSummaryJob();
 
         // This is a hack to override the `private` `PlatformStatsSummaryJob::mwHostResolver` property.
         // See https://www.php.net/manual/en/closure.call.php for more details on how this works.

--- a/tests/Jobs/PollForMediaWikiJobsJobTest.php
+++ b/tests/Jobs/PollForMediaWikiJobsJobTest.php
@@ -47,7 +47,7 @@ class PollForMediaWikiJobsJobTest extends TestCase {
 
         Bus::fake();
         $mockJob = $this->createMock(Job::class);
-        $job = new PollForMediaWikiJobsJob;
+        $job = new PollForMediaWikiJobsJob();
         $job->setJob($mockJob);
 
         $mockJob->expects($this->never())->method('fail');
@@ -70,7 +70,7 @@ class PollForMediaWikiJobsJobTest extends TestCase {
 
         $mockJob = $this->createMock(Job::class);
 
-        $job = new PollForMediaWikiJobsJob;
+        $job = new PollForMediaWikiJobsJob();
         $job->setJob($mockJob);
 
         $mockJob->expects($this->never())->method('fail');
@@ -89,7 +89,7 @@ class PollForMediaWikiJobsJobTest extends TestCase {
 
         $mockJob = $this->createMock(Job::class);
 
-        $job = new PollForMediaWikiJobsJob;
+        $job = new PollForMediaWikiJobsJob();
         $job->setJob($mockJob);
 
         $mockJob->expects($this->once())->method('markAsFailed');

--- a/tests/Jobs/RequeuePendingQsBatchesJobTest.php
+++ b/tests/Jobs/RequeuePendingQsBatchesJobTest.php
@@ -38,7 +38,7 @@ class RequeuePendingQsBatchesJobTest extends TestCase {
         $this->app->instance(ExceptionHandler::class, $mockExceptionHandler);
 
         $mockJob = $this->createMock(Job::class);
-        $job = new RequeuePendingQsBatchesJob;
+        $job = new RequeuePendingQsBatchesJob();
         $job->setJob($mockJob);
         $mockJob->expects($this->never())
             ->method('fail');

--- a/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
+++ b/tests/Jobs/SendEmptyWikiNotificationsJobTest.php
@@ -24,7 +24,7 @@ class SendEmptyWikiNotificationsJobTest extends TestCase {
         $mockJob->expects($this->never())
             ->method('fail')
             ->withAnyParameters();
-        $job = new SendEmptyWikiNotificationsJob;
+        $job = new SendEmptyWikiNotificationsJob();
         $job->setJob($mockJob);
         $job->handle();
     }
@@ -41,7 +41,7 @@ class SendEmptyWikiNotificationsJobTest extends TestCase {
         WikiManager::factory()->create(['wiki_id' => $wiki->id, 'user_id' => $user->id]);
         $wiki->wikiLifecycleEvents()->updateOrCreate(['first_edited' => null]);
 
-        $job = new SendEmptyWikiNotificationsJob;
+        $job = new SendEmptyWikiNotificationsJob();
         $job->handle();
 
         Notification::assertSentTo(
@@ -63,7 +63,7 @@ class SendEmptyWikiNotificationsJobTest extends TestCase {
         WikiManager::factory()->create(['wiki_id' => $wiki->id, 'user_id' => $user->id]);
         $wiki->wikiLifecycleEvents()->updateOrCreate(['first_edited' => null]);
 
-        $job = new SendEmptyWikiNotificationsJob;
+        $job = new SendEmptyWikiNotificationsJob();
         $job->handle();
 
         Notification::assertNothingSent();
@@ -78,7 +78,7 @@ class SendEmptyWikiNotificationsJobTest extends TestCase {
         $wiki = Wiki::factory()->create(['created_at' => $now]);
         $manager = WikiManager::factory()->create(['wiki_id' => $wiki->id, 'user_id' => $user->id]);
 
-        $job = new SendEmptyWikiNotificationsJob;
+        $job = new SendEmptyWikiNotificationsJob();
 
         $mockJob = $this->createMock(Job::class);
         $mockJob->expects($this->never())
@@ -109,7 +109,7 @@ class SendEmptyWikiNotificationsJobTest extends TestCase {
             'first_edited' => $now,
         ]);
 
-        $job = new SendEmptyWikiNotificationsJob;
+        $job = new SendEmptyWikiNotificationsJob();
         $job->handle();
 
         Notification::assertNothingSent();
@@ -132,7 +132,7 @@ class SendEmptyWikiNotificationsJobTest extends TestCase {
             'user_id' => $manager->user_id,
         ]);
 
-        $job = new SendEmptyWikiNotificationsJob;
+        $job = new SendEmptyWikiNotificationsJob();
         $job->handle();
 
         Notification::assertNothingSent();

--- a/tests/Jobs/UpdateQueryserviceAllowListTest.php
+++ b/tests/Jobs/UpdateQueryserviceAllowListTest.php
@@ -31,7 +31,7 @@ class UpdateQueryserviceAllowListTest extends TestCase {
                 "Queryservice config map 'queryservice-allowlist' does not exist."
             ));
 
-        $job = new UpdateQueryserviceAllowList;
+        $job = new UpdateQueryserviceAllowList();
         $job->setJob($mockJob);
 
         $mock = new MockHandler([
@@ -55,7 +55,7 @@ class UpdateQueryserviceAllowListTest extends TestCase {
         $mockJob = $this->createMock(Job::class);
         $mockJob->expects($this->never())->method('fail');
 
-        $job = new UpdateQueryserviceAllowList;
+        $job = new UpdateQueryserviceAllowList();
         $job->setJob($mockJob);
 
         $mock = new MockHandler([

--- a/tests/Jobs/UpdateWikiDailyMetricJobTest.php
+++ b/tests/Jobs/UpdateWikiDailyMetricJobTest.php
@@ -31,8 +31,8 @@ class UpdateWikiDailyMetricJobTest extends TestCase {
         ]);
 
         $manager = $this->app->make('db');
-        $job = new ProvisionWikiDbJob;
-        $job2 = new ProvisionWikiDbJob;
+        $job = new ProvisionWikiDbJob();
+        $job2 = new ProvisionWikiDbJob();
         $job->handle($manager);
         $job2->handle($manager);
 
@@ -44,7 +44,7 @@ class UpdateWikiDailyMetricJobTest extends TestCase {
 
         $deletedWiki->delete();
 
-        (new UpdateWikiDailyMetricJob)->handle();
+        (new UpdateWikiDailyMetricJob())->handle();
 
         $this->assertDatabaseHas('wiki_daily_metrics', [
             'wiki_id' => $activeWiki->id,

--- a/tests/Jobs/UpdateWikiSiteStatsJobTest.php
+++ b/tests/Jobs/UpdateWikiSiteStatsJobTest.php
@@ -155,7 +155,7 @@ class UpdateWikiSiteStatsJobTest extends TestCase {
         $this->fakeResponse();
 
         $mockJob = $this->createMock(Job::class);
-        $job = new UpdateWikiSiteStatsJob;
+        $job = new UpdateWikiSiteStatsJob();
         $job->setJob($mockJob);
 
         $mockJob->expects($this->never())->method('fail');
@@ -221,7 +221,7 @@ class UpdateWikiSiteStatsJobTest extends TestCase {
         $this->fakeResponse();
 
         $mockJob = $this->createMock(Job::class);
-        $job = new UpdateWikiSiteStatsJob;
+        $job = new UpdateWikiSiteStatsJob();
         $job->setJob($mockJob);
 
         $mockJob->expects($this->never())->method('fail');
@@ -254,7 +254,7 @@ class UpdateWikiSiteStatsJobTest extends TestCase {
         $this->fakeResponse();
 
         $mockJob = $this->createMock(Job::class);
-        $job = new UpdateWikiSiteStatsJob;
+        $job = new UpdateWikiSiteStatsJob();
         $job->setJob($mockJob);
 
         $mockJob->expects($this->never())->method('fail');
@@ -283,7 +283,7 @@ class UpdateWikiSiteStatsJobTest extends TestCase {
         $this->fakeResponse();
 
         $mockJob = $this->createMock(Job::class);
-        $job = new UpdateWikiSiteStatsJob;
+        $job = new UpdateWikiSiteStatsJob();
         $job->setJob($mockJob);
 
         $mockJob->expects($this->never())->method('fail');
@@ -305,7 +305,7 @@ class UpdateWikiSiteStatsJobTest extends TestCase {
         $this->fakeResponse();
 
         $mockJob = $this->createMock(Job::class);
-        $job = new UpdateWikiSiteStatsJob;
+        $job = new UpdateWikiSiteStatsJob();
         $job->setJob($mockJob);
 
         $mockJob->expects($this->never())->method('fail');

--- a/tests/Jobs/UserTermsOfUseAcceptanceTest.php
+++ b/tests/Jobs/UserTermsOfUseAcceptanceTest.php
@@ -13,7 +13,7 @@ class UserTermsOfUseAcceptanceTest extends TestCase {
     use RefreshDatabase;
 
     public function testUserCreationCreatesTouAcceptance(): void {
-        (new CreateFirstTermsOfUseVersionJob)->handle();
+        (new CreateFirstTermsOfUseVersionJob())->handle();
         $email = 'test+' . uniqid('', true) . '@example.com';
         $user = (new UserCreateJob($email, 'thisisapassword123', true))->handle();
 

--- a/tests/Jobs/UserTouAcceptanceJobTest.php
+++ b/tests/Jobs/UserTouAcceptanceJobTest.php
@@ -23,8 +23,8 @@ class UserTouAcceptanceJobTest extends TestCase {
         $u2 = User::factory()->create(['created_at' => $t2]);
         $u3 = User::factory()->create(['created_at' => $t3]);
 
-        (new CreateFirstTermsOfUseVersionJob)->handle();
-        (new UserTouAcceptanceJob)->handle();
+        (new CreateFirstTermsOfUseVersionJob())->handle();
+        (new UserTouAcceptanceJob())->handle();
 
         $latest = TermsOfUseVersion::latestActiveVersion()->version;
 

--- a/tests/Metrics/WikiMetricsTest.php
+++ b/tests/Metrics/WikiMetricsTest.php
@@ -22,7 +22,7 @@ class WikiMetricsTest extends TestCase {
     protected function setUp(): void {
         parent::setUp();
         $manager = $this->app->make('db');
-        $job = new ProvisionWikiDbJob;
+        $job = new ProvisionWikiDbJob();
         $job->handle($manager);
     }
 
@@ -34,7 +34,7 @@ class WikiMetricsTest extends TestCase {
         $wikiDb = WikiDb::first();
         $wikiDb->update(['wiki_id' => $wiki->id]);
 
-        (new WikiMetrics)->saveMetrics($wiki);
+        (new WikiMetrics())->saveMetrics($wiki);
 
         // Assert new record is added to the database
         $this->assertDatabaseHas('wiki_daily_metrics', [
@@ -60,7 +60,7 @@ class WikiMetricsTest extends TestCase {
         ]);
 
         // Run saveMetrics()
-        (new WikiMetrics)->saveMetrics($wiki);
+        (new WikiMetrics())->saveMetrics($wiki);
 
         // Assert no new record was created for today
         $this->assertDatabaseMissing('wiki_daily_metrics', [
@@ -98,7 +98,7 @@ class WikiMetricsTest extends TestCase {
         $wiki->save();
 
         // Run saveMetrics()
-        (new WikiMetrics)->saveMetrics($wiki);
+        (new WikiMetrics())->saveMetrics($wiki);
 
         // Assert new record was created for newly deleted wiki
         $this->assertDatabaseHas('wiki_daily_metrics', [
@@ -130,7 +130,7 @@ class WikiMetricsTest extends TestCase {
         ]);
 
         // Run saveMetrics()
-        (new WikiMetrics)->saveMetrics($wiki);
+        (new WikiMetrics())->saveMetrics($wiki);
 
         // Assert no new record was created for previously deleted wiki
         $this->assertDatabaseMissing('wiki_daily_metrics', [
@@ -151,7 +151,7 @@ class WikiMetricsTest extends TestCase {
         $this->assertNull($wiki->wikiSiteStats()->first());
 
         // Run saveMetrics()
-        (new WikiMetrics)->saveMetrics($wiki);
+        (new WikiMetrics())->saveMetrics($wiki);
 
         // Assert new record was created with default values
         $this->assertDatabaseHas('wiki_daily_metrics', [
@@ -195,7 +195,7 @@ class WikiMetricsTest extends TestCase {
                 ],
             ], 200),
         ]);
-        (new WikiMetrics)->saveMetrics($wiki);
+        (new WikiMetrics())->saveMetrics($wiki);
         $this->assertDatabaseHas('wiki_daily_metrics', [
             'wiki_id' => $wiki->id,
             'number_of_triples' => 12345,
@@ -227,7 +227,7 @@ class WikiMetricsTest extends TestCase {
         Http::fake([
             '*' => Http::response('Error', 500),
         ]);
-        (new WikiMetrics)->saveMetrics($wiki);
+        (new WikiMetrics())->saveMetrics($wiki);
         $this->assertDatabaseHas('wiki_daily_metrics', [
             'wiki_id' => $wiki->id,
             'number_of_triples' => null,
@@ -416,7 +416,7 @@ class WikiMetricsTest extends TestCase {
             'is_deleted' => 0,
         ]);
 
-        (new WikiMetrics)->saveMetrics($wiki);
+        (new WikiMetrics())->saveMetrics($wiki);
 
         // clean up after the test
         $wiki->forceDelete();

--- a/tests/Middleware/ThrottleSignupTest.php
+++ b/tests/Middleware/ThrottleSignupTest.php
@@ -42,8 +42,8 @@ class ThrottleSignupTest extends TestCase {
             ]
         );
 
-        $request = new Request;
-        $middleware = new ThrottleSignup;
+        $request = new Request();
+        $middleware = new ThrottleSignup();
         $called = false;
 
         $response = $middleware->handle($request, function ($req) use (&$called) {
@@ -75,8 +75,8 @@ class ThrottleSignupTest extends TestCase {
             ]
         );
 
-        $request = new Request;
-        $middleware = new ThrottleSignup;
+        $request = new Request();
+        $middleware = new ThrottleSignup();
         $called = false;
 
         $response = $middleware->handle($request, function ($req) use (&$called) {
@@ -108,8 +108,8 @@ class ThrottleSignupTest extends TestCase {
             ]
         );
 
-        $request = new Request;
-        $middleware = new ThrottleSignup;
+        $request = new Request();
+        $middleware = new ThrottleSignup();
         $called = false;
 
         $response = $middleware->handle($request, function ($req) use (&$called) {

--- a/tests/Routes/Complaint/SendMessageTest.php
+++ b/tests/Routes/Complaint/SendMessageTest.php
@@ -184,10 +184,10 @@ class SendMessageTest extends TestCase {
 
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(200);
-        Notification::assertSentTo(new AnonymousNotifiable, ComplaintNotification::class, function ($notification) {
+        Notification::assertSentTo(new AnonymousNotifiable(), ComplaintNotification::class, function ($notification) {
             $this->assertSame(
                 'dsa@wikibase.cloud',
-                $notification->toMail(new AnonymousNotifiable)->from[0]
+                $notification->toMail(new AnonymousNotifiable())->from[0]
             );
 
             return true;

--- a/tests/Routes/Contact/SendMessageTest.php
+++ b/tests/Routes/Contact/SendMessageTest.php
@@ -119,10 +119,10 @@ class SendMessageTest extends TestCase {
 
         $response = $this->json('POST', $this->route, $data);
         $response->assertStatus(200);
-        Notification::assertSentTo(new AnonymousNotifiable, ContactNotification::class, function ($notification) {
+        Notification::assertSentTo(new AnonymousNotifiable(), ContactNotification::class, function ($notification) {
             $this->assertSame(
                 'contact-general-question@wikibase.cloud',
-                $notification->toMail(new AnonymousNotifiable)->from[0]
+                $notification->toMail(new AnonymousNotifiable())->from[0]
             );
 
             return true;

--- a/tests/Routes/Wiki/CreateTest.php
+++ b/tests/Routes/Wiki/CreateTest.php
@@ -148,10 +148,10 @@ class CreateTest extends TestCase {
     public function testCreateWikiLimitsNumWikisPerUser() {
         $manager = $this->app->make('db');
 
-        $job1 = new ProvisionWikiDbJob;
+        $job1 = new ProvisionWikiDbJob();
         $job1->handle($manager);
 
-        $job2 = new ProvisionWikiDbJob;
+        $job2 = new ProvisionWikiDbJob();
         $job2->handle($manager);
 
         QueryserviceNamespace::create([
@@ -223,7 +223,7 @@ class CreateTest extends TestCase {
 
     private function createSQLandQSDBs(): void {
         $manager = $this->app->make('db');
-        $job = new ProvisionWikiDbJob;
+        $job = new ProvisionWikiDbJob();
         $job->handle($manager);
 
         QueryserviceNamespace::create([

--- a/tests/Services/MediaWikiHostResolverTest.php
+++ b/tests/Services/MediaWikiHostResolverTest.php
@@ -14,9 +14,9 @@ class MediaWikiHostResolverTest extends TestCase {
     use RefreshDatabase;
 
     public function testResolverRoutesToCorrectHost(): void {
-        $domain = (new Factory)->create()->unique()->text(30);
+        $domain = (new Factory())->create()->unique()->text(30);
         $this->createWiki($domain, 'mw1.43-wbs2');
-        $resolver = new MediaWikiHostResolver;
+        $resolver = new MediaWikiHostResolver();
         $this->assertEquals(
             'mediawiki-143-app-backend.default.svc.cluster.local',
             $resolver->getBackendHostForDomain($domain)
@@ -36,9 +36,9 @@ class MediaWikiHostResolverTest extends TestCase {
     }
 
     public function testResolverThrowsIfUnableToFindHostInMap(): void {
-        $domain = (new Factory)->create()->unique()->text(30);
+        $domain = (new Factory())->create()->unique()->text(30);
         $this->createWiki($domain, 'mw1.43-unmapped');
-        $resolver = new MediaWikiHostResolver;
+        $resolver = new MediaWikiHostResolver();
         $this->assertThrows(
             fn () => $resolver->getBackendHostForDomain($domain),
             UnknownDBVersionException::class
@@ -46,8 +46,8 @@ class MediaWikiHostResolverTest extends TestCase {
     }
 
     public function testResolverThrowsIfUnableToFindWiki(): void {
-        $domain = (new Factory)->create()->unique()->text(30);
-        $resolver = new MediaWikiHostResolver;
+        $domain = (new Factory())->create()->unique()->text(30);
+        $resolver = new MediaWikiHostResolver();
         $this->assertThrows(
             fn () => $resolver->getBackendHostForDomain($domain),
             UnknownWikiDomainException::class


### PR DESCRIPTION
Set the `laravel/pint` config `new_with_parentheses` to `true` to make it more explicit that a new instance is created.

Bug: T428714