### PR TITLE
tests: prevent output in phpunit tests

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -9,6 +9,8 @@
   xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
   cacheDirectory=".phpunit.cache"
   backupStaticProperties="false"
+  beStrictAboutOutputDuringTests="true"
+  failOnRisky="true"
 >
   <testsuites>
     <testsuite name="Application Test Suite">

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,15 +1,25 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" bootstrap="bootstrap/app.php" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  backupGlobals="false"
+  bootstrap="bootstrap/app.php"
+  colors="true"
+  processIsolation="false"
+  stopOnFailure="false"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  cacheDirectory=".phpunit.cache"
+  backupStaticProperties="false"
+>
   <testsuites>
     <testsuite name="Application Test Suite">
       <directory suffix="Test.php">./tests</directory>
     </testsuite>
   </testsuites>
   <php>
-    <env name="APP_ENV" value="testing"/>
-    <env name="CACHE_DRIVER" value="array"/>
-    <env name="QUEUE_CONNECTION" value="sync"/>
-    <env name="WBSTACK_SUMMARY_CREATION_RATE_RANGES" value="PT24H,P30D"/>
+    <env name="APP_ENV" value="testing" />
+    <env name="CACHE_DRIVER" value="array" />
+    <env name="QUEUE_CONNECTION" value="sync" />
+    <env name="WBSTACK_SUMMARY_CREATION_RATE_RANGES" value="PT24H,P30D" />
   </php>
   <source>
     <include>

--- a/tests/Jobs/Integration/ElasticSearchIndexDeleteTest.php
+++ b/tests/Jobs/Integration/ElasticSearchIndexDeleteTest.php
@@ -48,12 +48,11 @@ class ElasticSearchIndexDeleteTest extends TestCase {
         );
         $response = $curlRequest->execute();
         $err = $curlRequest->error();
-        var_dump($response);
+        $curlRequest->close();
 
         if ($err) {
-            var_dump($err);
+            $this->fail("Request returned an error: {$err}");
         }
-        $curlRequest->close();
 
         return json_decode($response, true);
     }


### PR DESCRIPTION
I noticed an accidental `echo` left in a test during a recent review. It's best practice to avoid output during tests. Update PHPUnit config to make CI fail, rather than relying on human code review.

* Modify `ElasticSearchIndexDeleteTest` so it doesn't print output.
* `beStrictAboutOutputDuringTests` marks tests as "risky" if there is output printed.
* `failOnRisky` makes the test suite fail if any tests are marked as "risky".

Bug: T428716