### PR TITLE
default to JSON responses for exceptions

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -25,4 +25,8 @@ class Handler extends ExceptionHandler {
             (new ErrorReporting())->report($e);
         });
     }
+
+    protected function shouldReturnJson($request, Throwable $e): bool {
+        return true;
+    }
 }


### PR DESCRIPTION
Overwrite the default error handler in our custom handler to so it shouldReturnJson is always true.

This prevents http responses (and the confusing redirect) with ValidationExceptions

Bug: T429021