### PR TITLE
chore: fix warnings from docker build step

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM composer:2.10 as composer
+FROM composer:2.10 AS composer
 
 COPY ./composer.json /tmp/src1/composer.json
 COPY ./composer.lock /tmp/src1/composer.lock
@@ -32,7 +32,7 @@ RUN apt-get update \
 	&& docker-php-ext-enable opencensus \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV APACHE_DOCUMENT_ROOT /var/www/html/public
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public
 
 # Change the document root
 RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf \


### PR DESCRIPTION
There are warnings in the docker build step. These are also shown in the PR review UI.

Resolving them means that we will have less noise to read when reviewing PRs and it means we're better following docker best practices.

Bug: T429818