### PR TITLE
Add PolicySeeder

### DIFF
--- a/app/Policy.php
+++ b/app/Policy.php
@@ -45,7 +45,6 @@ class Policy extends Model {
             // cast `active_from` to a CarbonImmutable instance rather than a string
             'active_from' => 'immutable_date',
 
-            // TODO: should we make Laravel use CarbonImmutable globally instead of casting in models?
             'created_at' => 'immutable_datetime',
             'updated_at' => 'immutable_datetime',
         ];

--- a/app/Policy.php
+++ b/app/Policy.php
@@ -8,12 +8,12 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @property-read int $id
+ * @property int $id
  * @property string $policy_type
  * @property CarbonImmutable|null $active_from
  * @property string $content_vue_file
- * @property CarbonImmutable $created_at
- * @property CarbonImmutable $updated_at
+ * @property CarbonImmutable|null $created_at
+ * @property CarbonImmutable|null $updated_at
  *
  * @method static Builder<static>|Policy newModelQuery()
  * @method static Builder<static>|Policy newQuery()

--- a/app/Policy.php
+++ b/app/Policy.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App;
+
+use Carbon\CarbonImmutable;
+use Eloquent;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @property-read int $id
+ * @property string $policy_type
+ * @property CarbonImmutable|null $active_from
+ * @property string $content_vue_file
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ *
+ * @method static Builder<static>|Policy newModelQuery()
+ * @method static Builder<static>|Policy newQuery()
+ * @method static Builder<static>|Policy query()
+ * @method static Builder<static>|Policy whereActiveFrom($value)
+ * @method static Builder<static>|Policy whereContentVueFile($value)
+ * @method static Builder<static>|Policy whereCreatedAt($value)
+ * @method static Builder<static>|Policy whereId($value)
+ * @method static Builder<static>|Policy wherePolicyType($value)
+ * @method static Builder<static>|Policy whereUpdatedAt($value)
+ *
+ * @mixin Eloquent
+ */
+class Policy extends Model {
+    // TODO: also create a factory (and seeder)?
+
+    // define which attributes are mass assignable
+    protected $fillable = [
+        'policy_type',
+        'active_from',
+        'content_vue_file',
+    ];
+
+    // define the default value of model attributes when a new instance is created
+    protected $attributes = [
+        'active_from' => null,
+    ];
+
+    protected function casts(): array {
+        return [
+            // cast `active_from` to a CarbonImmutable instance rather than a string
+            'active_from' => 'immutable_date',
+
+            // TODO: should we make Laravel use CarbonImmutable globally instead of casting in models?
+            'created_at' => 'immutable_datetime',
+            'updated_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/app/Policy.php
+++ b/app/Policy.php
@@ -28,8 +28,6 @@ use Illuminate\Database\Eloquent\Model;
  * @mixin Eloquent
  */
 class Policy extends Model {
-    // TODO: also create a factory (and seeder)?
-
     // define which attributes are mass assignable
     protected $fillable = [
         'policy_type',

--- a/app/PolicyAcceptance.php
+++ b/app/PolicyAcceptance.php
@@ -32,14 +32,16 @@ use Illuminate\Database\Eloquent\Model;
  * @mixin Eloquent
  */
 class PolicyAcceptance extends Model {
-    // TODO: also create a factory (and seeder)?
-
-    // define which attributes are mass assignable
     protected $fillable = [
         'user_id',
         'policy_id',
-        // Don't allow `accepted_at` to be mass assigned? Most of the time this will be set to the current timestamp by the database.
-        // 'accepted_at',
+
+    ];
+
+    protected $guarded = [
+        // Don't allow `accepted_at` to be mass assigned.
+        // Most of the time this will be set to the current timestamp by the database.
+        'accepted_at',
     ];
 
     protected function casts(): array {
@@ -48,6 +50,7 @@ class PolicyAcceptance extends Model {
             'accepted_at' => 'immutable_datetime',
 
             // TODO: should we make Laravel use CarbonImmutable globally instead of casting in models?
+            // TODO: should we do any casting with these built ins?
             'created_at' => 'immutable_datetime',
             'updated_at' => 'immutable_datetime',
         ];

--- a/app/PolicyAcceptance.php
+++ b/app/PolicyAcceptance.php
@@ -12,12 +12,12 @@ use Illuminate\Database\Eloquent\Model;
  *   - it reduces confuses by remaining consistent with other models that use the default timestamps
  *   - `accepted_at` will be before `created_at` when backfilling the terms-of-use acceptances
  *
- * @property-read int $id
+ * @property int $id
  * @property int $user_id
  * @property int $policy_id
+ * @property CarbonImmutable|null $created_at
+ * @property CarbonImmutable|null $updated_at
  * @property CarbonImmutable $accepted_at
- * @property CarbonImmutable $created_at
- * @property CarbonImmutable $updated_at
  *
  * @method static Builder<static>|PolicyAcceptance newModelQuery()
  * @method static Builder<static>|PolicyAcceptance newQuery()

--- a/app/PolicyAcceptance.php
+++ b/app/PolicyAcceptance.php
@@ -49,8 +49,6 @@ class PolicyAcceptance extends Model {
             // cast `accepted_at` to a `CarbonImmutable` instance rather than a string
             'accepted_at' => 'immutable_datetime',
 
-            // TODO: should we make Laravel use CarbonImmutable globally instead of casting in models?
-            // TODO: should we do any casting with these built ins?
             'created_at' => 'immutable_datetime',
             'updated_at' => 'immutable_datetime',
         ];

--- a/app/PolicyAcceptance.php
+++ b/app/PolicyAcceptance.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App;
+
+use Carbon\CarbonImmutable;
+use Eloquent;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * This model uses a separate `accepted_at` property rather than renaming the default `created_at` property because:
+ *   - it reduces confuses by remaining consistent with other models that use the default timestamps
+ *   - `accepted_at` will be before `created_at` when backfilling the terms-of-use acceptances
+ *
+ * @property-read int $id
+ * @property int $user_id
+ * @property int $policy_id
+ * @property CarbonImmutable $accepted_at
+ * @property CarbonImmutable $created_at
+ * @property CarbonImmutable $updated_at
+ *
+ * @method static Builder<static>|PolicyAcceptance newModelQuery()
+ * @method static Builder<static>|PolicyAcceptance newQuery()
+ * @method static Builder<static>|PolicyAcceptance query()
+ * @method static Builder<static>|PolicyAcceptance whereAcceptedAt($value)
+ * @method static Builder<static>|PolicyAcceptance whereCreatedAt($value)
+ * @method static Builder<static>|PolicyAcceptance whereId($value)
+ * @method static Builder<static>|PolicyAcceptance wherePolicyId($value)
+ * @method static Builder<static>|PolicyAcceptance whereUpdatedAt($value)
+ * @method static Builder<static>|PolicyAcceptance whereUserId($value)
+ *
+ * @mixin Eloquent
+ */
+class PolicyAcceptance extends Model {
+    // TODO: also create a factory (and seeder)?
+
+    // define which attributes are mass assignable
+    protected $fillable = [
+        'user_id',
+        'policy_id',
+        // Don't allow `accepted_at` to be mass assigned? Most of the time this will be set to the current timestamp by the database.
+        // 'accepted_at',
+    ];
+
+    protected function casts(): array {
+        return [
+            // cast `accepted_at` to a `CarbonImmutable` instance rather than a string
+            'accepted_at' => 'immutable_datetime',
+
+            // TODO: should we make Laravel use CarbonImmutable globally instead of casting in models?
+            'created_at' => 'immutable_datetime',
+            'updated_at' => 'immutable_datetime',
+        ];
+    }
+}

--- a/database/migrations/2026_06_22_083853_create_policies_table.php
+++ b/database/migrations/2026_06_22_083853_create_policies_table.php
@@ -11,18 +11,15 @@ return new class() extends Migration {
     public function up(): void {
         Schema::create('policies', function (Blueprint $table) {
             $table->id();
-            // TODO: or should this column name just be `type`?
             $table->enum('policy_type', ['terms-of-use', 'hosting-policy']);
             $table->date('active_from')->nullable()->default(null);
-            // TODO: or `content_reference`?
             $table->string('content_vue_file', 255);
 
             // Use Eloquent built in to create nullable `created_at` and `updated_at`
             // timestamp fields
             $table->timestamps();
 
-            // TODO: won't be able to create two upcoming policies of the same type with `active_from` set to `null`,
-            // but that seems like a reasonable restriction
+            // This prevents two upcoming policies of the same type with `active_from` set to `null`,
             $table->unique(['policy_type', 'active_from']);
         });
     }

--- a/database/migrations/2026_06_22_083853_create_policies_table.php
+++ b/database/migrations/2026_06_22_083853_create_policies_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::create('policies', function (Blueprint $table) {
+            $table->id();
+            // TODO: or should this column name just be `type`?
+            $table->enum('policy_type', ['terms-of-use', 'hosting-policy']);
+            $table->date('active_from')->nullable()->default(null);
+            // TODO: or `content_reference`?
+            $table->string('content_vue_file', 255);
+
+            // explicitly define the default timestamp columns so that they are not nullable
+            $table->timestamp('created_at');
+            $table->timestamp('updated_at');
+
+            // TODO: won't be able to create two upcoming policies of the same type with `active_from` set to `null`,
+            // but that seems like a reasonable restriction
+            $table->unique(['policy_type', 'active_from']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::dropIfExists('policies');
+    }
+};

--- a/database/migrations/2026_06_22_083853_create_policies_table.php
+++ b/database/migrations/2026_06_22_083853_create_policies_table.php
@@ -17,9 +17,9 @@ return new class() extends Migration {
             // TODO: or `content_reference`?
             $table->string('content_vue_file', 255);
 
-            // explicitly define the default timestamp columns so that they are not nullable
-            $table->timestamp('created_at');
-            $table->timestamp('updated_at');
+            // Use Eloquent built in to create nullable `created_at` and `updated_at`
+            // timestamp fields
+            $table->timestamps();
 
             // TODO: won't be able to create two upcoming policies of the same type with `active_from` set to `null`,
             // but that seems like a reasonable restriction

--- a/database/migrations/2026_06_22_083910_create_policy_acceptances_table.php
+++ b/database/migrations/2026_06_22_083910_create_policy_acceptances_table.php
@@ -18,14 +18,14 @@ return new class() extends Migration {
 
             $table->foreignId('policy_id')->constrained()->restrictOnUpdate()->restrictOnDelete();
 
+            // Use Eloquent built in to create nullable `created_at` and `updated_at`
+            // timestamp fields
+            $table->timestamps();
+
             // Using a separate `accepted_at` column rather than renaming the default `created_at` column because:
             //   * it reduces confuses by remaining consistent with other tables that use the default columns
             //   * `accepted_at` will be before `created_at` when backfilling the terms-of-use acceptances
             $table->timestamp('accepted_at')->useCurrent();
-
-            // explicitly define the default timestamp columns so that they are not nullable
-            $table->timestamp('created_at');
-            $table->timestamp('updated_at');
         });
     }
 

--- a/database/migrations/2026_06_22_083910_create_policy_acceptances_table.php
+++ b/database/migrations/2026_06_22_083910_create_policy_acceptances_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    /**
+     * Run the migrations.
+     */
+    public function up(): void {
+        Schema::create('policy_acceptances', function (Blueprint $table) {
+            $table->id();
+
+            // Can't use the `foreignId()` method because the `users.id` column isn't an unsigned big integer
+            $table->unsignedInteger('user_id');
+            $table->foreign('user_id')->references('id')->on('users')->restrictOnUpdate()->restrictOnDelete();
+
+            $table->foreignId('policy_id')->constrained()->restrictOnUpdate()->restrictOnDelete();
+
+            // Using a separate `accepted_at` column rather than renaming the default `created_at` column because:
+            //   * it reduces confuses by remaining consistent with other tables that use the default columns
+            //   * `accepted_at` will be before `created_at` when backfilling the terms-of-use acceptances
+            $table->timestamp('accepted_at')->useCurrent();
+
+            // explicitly define the default timestamp columns so that they are not nullable
+            $table->timestamp('created_at');
+            $table->timestamp('updated_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void {
+        Schema::dropIfExists('policy_acceptances');
+    }
+};

--- a/database/migrations/2026_06_22_083910_create_policy_acceptances_table.php
+++ b/database/migrations/2026_06_22_083910_create_policy_acceptances_table.php
@@ -23,7 +23,7 @@ return new class() extends Migration {
             $table->timestamps();
 
             // Using a separate `accepted_at` column rather than renaming the default `created_at` column because:
-            //   * it reduces confuses by remaining consistent with other tables that use the default columns
+            //   * it reduces confusion by remaining consistent with other tables that use the default columns
             //   * `accepted_at` will be before `created_at` when backfilling the terms-of-use acceptances
             $table->timestamp('accepted_at')->useCurrent();
         });

--- a/database/seeds/PolicySeeder.php
+++ b/database/seeds/PolicySeeder.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Policy;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Seeder;
+
+class PolicySeeder extends Seeder {
+    public function run() {
+        Policy::create(
+            [
+                'policy_type' => 'terms-of-use',
+                'active_from' => CarbonImmutable::createFromDate(2026, 06, 01),
+                'content_vue_file' => 'terms-of-use/example.vue',
+            ]
+        );
+    }
+}

--- a/tests/PolicyAcceptanceTest.php
+++ b/tests/PolicyAcceptanceTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests;
+
+use App\Policy;
+use App\PolicyAcceptance;
+use App\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class PolicyAcceptanceTest extends TestCase {
+    use RefreshDatabase;
+
+    protected int $user_id;
+
+    protected int $policy_id;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $user = User::factory()->create();
+        $this->user_id = $user->id;
+        $policy = Policy::create(
+            [
+                'policy_type' => 'terms-of-use',
+                'active_from' => CarbonImmutable::yesterday(),
+                'content_vue_file' => 'terms-of-use/example.vue',
+            ]);
+        $policy->save();
+        $this->policy_id = $policy->id;
+    }
+
+    public function testCreatesAndSavesSuccessfully(): void {
+        $policyAcceptance = new PolicyAcceptance(
+            [
+                'user_id' => $this->user_id,
+                'policy_id' => $this->policy_id,
+            ]
+        );
+        $policyAcceptance->save();
+        $policyAcceptance->refresh();
+
+        $this->assertDatabaseHas('policy_acceptances', [
+            'user_id' => $this->user_id,
+            'policy_id' => $this->policy_id,
+        ]);
+
+        $this->assertNotEmpty($policyAcceptance->accepted_at);
+    }
+}

--- a/tests/PolicyTest.php
+++ b/tests/PolicyTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Tests;
+
+use App\Policy;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class PolicyTest extends TestCase {
+    use RefreshDatabase;
+
+    public function testCreatesAndSavesSuccessfully(): void {
+        $yesterday = Carbon::yesterday();
+        $policy = Policy::create(
+            [
+                'policy_type' => 'terms-of-use',
+                'active_from' => $yesterday,
+                'content_vue_file' => 'terms-of-use/example.vue',
+            ]
+        );
+        $policy->save();
+
+        $this->assertDatabaseHas('policies', [
+            'policy_type' => 'terms-of-use',
+            'active_from' => $yesterday,
+            'content_vue_file' => 'terms-of-use/example.vue',
+        ]);
+    }
+}


### PR DESCRIPTION
Creates a new Seeder for easily creating Policy locally. This is not automatically run with `php artisan db:seed` since I intend to follow up with separating out Seeders into those we may wish to run only in test or dev and those we may wish to run in Prod

Bug: T430090