### PR TITLE
Add endpoint for creating a policy acceptance for a specific user

### DIFF
--- a/app/Http/Controllers/PolicyAcceptanceController.php
+++ b/app/Http/Controllers/PolicyAcceptanceController.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Policy;
+use App\PolicyAcceptance;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class PolicyAcceptanceController extends Controller {
+    public function store(Request $request): JsonResponse {
+        $request->validate([
+            'policy_ids' => ['required', 'array'],
+            'policy_ids.*' => ['integer'],
+        ]);
+
+        $policyIds = $request->input('policy_ids');
+
+        // Check all policy IDs exist before writing anything
+        $existingIds = Policy::whereIn('id', $policyIds)->pluck('id')->all();
+        $missingIds = array_values(array_diff($policyIds, $existingIds));
+
+        if (!empty($missingIds)) {
+            return response()->json([
+                'success' => false,
+                'message' => 'Some policy IDs do not exist.',
+                'data' => ['missing_policy_ids' => $missingIds],
+            ], 400);
+        }
+
+        $userId = $request->user()->id;
+
+        foreach ($policyIds as $policyId) {
+            // Ignore if the user has already accepted this policy
+            PolicyAcceptance::firstOrCreate(
+                ['user_id' => $userId, 'policy_id' => $policyId],
+                ['accepted_at' => now()],
+            );
+        }
+
+        return response()->json(['success' => true]);
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -29,7 +29,7 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router): v
         $router->delete('auth/login', ['uses' => 'Auth\LoginController@deleteLogin']);
 
         // policy acceptances
-        $router->put('policy_acceptances', ['uses' => 'PolicyAcceptanceController@store']);
+        $router->put('v1/policy_acceptances', ['uses' => 'PolicyAcceptanceController@store']);
 
         // user
         $router->group(['prefix' => 'user'], function () use ($router): void {

--- a/routes/api.php
+++ b/routes/api.php
@@ -28,6 +28,9 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router): v
         $router->get('auth/login', ['uses' => 'Auth\LoginController@getLogin']);
         $router->delete('auth/login', ['uses' => 'Auth\LoginController@deleteLogin']);
 
+        // policy acceptances
+        $router->put('policy_acceptances', ['uses' => 'PolicyAcceptanceController@store']);
+
         // user
         $router->group(['prefix' => 'user'], function () use ($router): void {
             $router->post('sendVerifyEmail', ['uses' => 'UserVerificationTokenController@createAndSendForUser']);

--- a/tests/Routes/PolicyAcceptanceControllerTest.php
+++ b/tests/Routes/PolicyAcceptanceControllerTest.php
@@ -11,7 +11,7 @@ use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
 class PolicyAcceptanceControllerTest extends TestCase {
-    protected $route = 'policy_acceptances';
+    protected $route = 'v1/policy_acceptances';
 
     use DatabaseTransactions;
 

--- a/tests/Routes/PolicyAcceptanceControllerTest.php
+++ b/tests/Routes/PolicyAcceptanceControllerTest.php
@@ -139,4 +139,19 @@ class PolicyAcceptanceControllerTest extends TestCase {
             ->assertStatus(422)
             ->assertJsonStructure(['errors' => ['policy_ids']]);
     }
+
+    public function testPolicyIdsContainingNonIntegerReturns422(): void {
+        $user = User::factory()->create();
+        $policy = $this->makePolicy();
+
+        $this->actingAs($user, 'api')
+            ->json('PUT', $this->route, ['policy_ids' => [$policy->id, 'abc']])
+            ->assertStatus(422)
+            ->assertJsonStructure(['errors' => ['policy_ids.1']]);
+
+        $this->assertDatabaseMissing('policy_acceptances', [
+            'user_id' => $user->id,
+            'policy_id' => $policy->id,
+        ]);
+    }
 }

--- a/tests/Routes/PolicyAcceptanceControllerTest.php
+++ b/tests/Routes/PolicyAcceptanceControllerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Routes;
+
+use App\Policy;
+use App\PolicyAcceptance;
+use App\User;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class PolicyAcceptanceControllerTest extends TestCase {
+    protected $route = 'policy_acceptances';
+
+    use DatabaseTransactions;
+
+    private function makePolicy(string $type = 'terms-of-use'): Policy {
+        $policy = new Policy();
+        $policy->policy_type = $type;
+        $policy->active_from = CarbonImmutable::now();
+        $policy->content_vue_file = $type . '/version-1.vue';
+        $policy->save();
+
+        return $policy;
+    }
+
+    public function testUnauthenticatedRequestResponds401(): void {
+        $this->json('PUT', $this->route)
+            ->assertStatus(401);
+    }
+
+    public function testAcceptSinglePolicy(): void {
+        $user = User::factory()->create();
+        $policy = $this->makePolicy();
+
+        $this->actingAs($user, 'api')
+            ->json('PUT', $this->route, ['policy_ids' => [$policy->id]])
+            ->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        $this->assertDatabaseHas('policy_acceptances', [
+            'user_id' => $user->id,
+            'policy_id' => $policy->id,
+        ]);
+    }
+
+    public function testAcceptMultiplePolicies(): void {
+        $user = User::factory()->create();
+        $termsOfUse = $this->makePolicy('terms-of-use');
+        $hostingPolicy = $this->makePolicy('hosting-policy');
+
+        $this->actingAs($user, 'api')
+            ->json('PUT', $this->route, ['policy_ids' => [$termsOfUse->id, $hostingPolicy->id]])
+            ->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        $this->assertDatabaseHas('policy_acceptances', ['user_id' => $user->id, 'policy_id' => $termsOfUse->id]);
+        $this->assertDatabaseHas('policy_acceptances', ['user_id' => $user->id, 'policy_id' => $hostingPolicy->id]);
+    }
+
+    public function testAlreadyAcceptedPolicyIsIgnored(): void {
+        $user = User::factory()->create();
+        $policy = $this->makePolicy();
+
+        PolicyAcceptance::create([
+            'user_id' => $user->id,
+            'policy_id' => $policy->id,
+            'accepted_at' => now(),
+        ]);
+
+        $this->actingAs($user, 'api')
+            ->json('PUT', $this->route, ['policy_ids' => [$policy->id]])
+            ->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        $this->assertSame(1, PolicyAcceptance::where([
+            'user_id' => $user->id,
+            'policy_id' => $policy->id,
+        ])->count());
+    }
+
+    public function testNonExistentPolicyIdReturns400(): void {
+        $user = User::factory()->create();
+        $policy = $this->makePolicy();
+        $nonExistentId = 999999;
+
+        $this->actingAs($user, 'api')
+            ->json('PUT', $this->route, ['policy_ids' => [$policy->id, $nonExistentId]])
+            ->assertStatus(400)
+            ->assertJsonFragment(['success' => false])
+            ->assertJsonFragment(['missing_policy_ids' => [$nonExistentId]]);
+
+        // Nothing should have been written
+        $this->assertDatabaseMissing('policy_acceptances', [
+            'user_id' => $user->id,
+            'policy_id' => $policy->id,
+        ]);
+    }
+
+    public function testMissingPolicyIdsFieldReturns422(): void {
+        $user = User::factory()->create();
+
+        $this->actingAs($user, 'api')
+            ->json('PUT', $this->route, [])
+            ->assertStatus(422)
+            ->assertJsonStructure(['errors' => ['policy_ids']]);
+    }
+
+    public function testPolicyIdsNotAnArrayReturns422(): void {
+        $user = User::factory()->create();
+
+        $this->actingAs($user, 'api')
+            ->json('PUT', $this->route, ['policy_ids' => 'not-an-array'])
+            ->assertStatus(422)
+            ->assertJsonStructure(['errors' => ['policy_ids']]);
+    }
+}

--- a/tests/Routes/PolicyAcceptanceControllerTest.php
+++ b/tests/Routes/PolicyAcceptanceControllerTest.php
@@ -5,6 +5,7 @@ namespace Tests\Routes;
 use App\Policy;
 use App\PolicyAcceptance;
 use App\User;
+use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
@@ -77,6 +78,30 @@ class PolicyAcceptanceControllerTest extends TestCase {
             'user_id' => $user->id,
             'policy_id' => $policy->id,
         ])->count());
+    }
+
+    public function testAlreadyAcceptedPolicyKeepsOriginalAcceptedAt(): void {
+        $user = User::factory()->create();
+        $policy = $this->makePolicy();
+
+        $originalAcceptedAt = CarbonImmutable::create(2026, 7, 1, 10, 0, 0);
+        Carbon::setTestNow(CarbonImmutable::create(2026, 7, 2, 10, 0, 0));
+
+        PolicyAcceptance::create([
+            'user_id' => $user->id,
+            'policy_id' => $policy->id,
+            'accepted_at' => $originalAcceptedAt,
+        ]);
+
+        $this->actingAs($user, 'api')
+            ->json('PUT', $this->route, ['policy_ids' => [$policy->id]])
+            ->assertStatus(200)
+            ->assertJson(['success' => true]);
+
+        $this->assertEquals($originalAcceptedAt->toDateTimeString(), PolicyAcceptance::where([
+            'user_id' => $user->id,
+            'policy_id' => $policy->id,
+        ])->first()->accepted_at->toDateTimeString());
     }
 
     public function testNonExistentPolicyIdReturns400(): void {


### PR DESCRIPTION
**Summary**
- Add authenticated endpoint to record policy acceptances for the current user, with strict validation and all-or-nothing behavior for invalid policy IDs.

**Behavior**
- Uses authenticated user from session context (no `user_id` in payload)
- Ignores already-accepted policies (idempotent writes via `firstOrCreate`)
- If any provided policy ID does not exist, returns `400` with `missing_policy_ids`
- No acceptances are created when invalid policy IDs are present
- Returns `422` for invalid payload (missing `policy_ids`, non-array, non-integer items)

Bug: T431674