### PR TITLE
Prototype: Add Models, Controllers for Suspensions and Submissions

### DIFF
--- a/app/ActiveSuspension.php
+++ b/app/ActiveSuspension.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ActiveSuspension extends Model
+{
+    protected $fillable = [
+        'since',
+        'wiki_id'
+    ];
+}

--- a/app/ActiveSuspension.php
+++ b/app/ActiveSuspension.php
@@ -10,4 +10,8 @@ class ActiveSuspension extends Model
         'since',
         'wiki_id'
     ];
+
+    public function Wiki(): BelongsTo {
+        return $this->belongsTo(Wiki::class);
+    }
 }

--- a/app/Http/Controllers/ActiveSuspensionController.php
+++ b/app/Http/Controllers/ActiveSuspensionController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\ActiveSuspension;
+use Illuminate\Http\Request;
+
+class ActiveSuspensionController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        // Possible for anyone
+        // TODO: implement
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        // Only possible for admin
+        return ActiveSuspension::create([
+            'since' => $request->input('since'),
+            'wiki_id' => $request->input('wiki_id')
+        ]);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(ActiveSuspension $activeSuspension)
+    {
+        // Possible for anyone
+        // TODO: implement
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, ActiveSuspension $activeSuspension)
+    {
+        // Only possible for admin
+        // TODO: implement
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(ActiveSuspension $suspension)
+    {
+        $suspension->first()->delete();
+    }
+}

--- a/app/Http/Controllers/ReviewSubmissionController.php
+++ b/app/Http/Controllers/ReviewSubmissionController.php
@@ -2,8 +2,13 @@
 
 namespace App\Http\Controllers;
 
+use App\ActiveSuspension;
 use App\ReviewSubmission;
+use App\ScheduledSuspension;
+use App\Wiki;
+use Carbon\CarbonImmutable;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 
 class ReviewSubmissionController extends Controller
 {
@@ -42,7 +47,33 @@ class ReviewSubmissionController extends Controller
     public function update(Request $request, ReviewSubmission $reviewSubmission)
     {
         // Only possible for admin to pick up/approv, normal Wikimanager can cancel
+        if ($request->input('status') === 'cancelled') {
+            $loadedSubmission = $reviewSubmission->get()->first();
+            $loadedSubmission->status = $request->input('status');
 
+            DB::transaction( function () use ($loadedSubmission)  {
+                $wiki = $loadedSubmission->wiki;
+                $loadedSubmission->save();
+                $this->enactAnyPendingScheduledSuspensionsOnCancellation($wiki);
+            });
+        }
+    }
+
+    private function enactAnyPendingScheduledSuspensionsOnCancellation( Wiki $wiki ): void {
+        // var_dump($wiki);
+        $scheduledSuspension = ScheduledSuspension::where(['wiki_id' => $wiki->id])->first();
+        // var_dump($scheduledSuspension);
+        if( $scheduledSuspension && $scheduledSuspension->schedulingDue()) {
+            ActiveSuspension::create([
+                'wiki_id' => $wiki->id,
+                'since' => CarbonImmutable::now(),
+                'reason' => $scheduledSuspension->reason
+            ]);
+            $scheduledSuspension->delete();
+    }
+//if there are any scheduled suspensions
+//and they should have been processed
+//make them active and remove the scheduled suspension
     }
 
     /**

--- a/app/Http/Controllers/ReviewSubmissionController.php
+++ b/app/Http/Controllers/ReviewSubmissionController.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\ReviewSubmission;
+use Illuminate\Http\Request;
+
+class ReviewSubmissionController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        // Only possible for Admin
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        // Possible for Admin or Authed user
+        // Authed user can only create pending "submitted" status
+        $submission = new ReviewSubmission();
+        $submission->status = 'submitted';
+        $submission->wiki_id = $request->input('wiki_id');
+        $submission->save();
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(ReviewSubmission $reviewSubmission)
+    {
+        // Possible for admin or specifically authed user
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, ReviewSubmission $reviewSubmission)
+    {
+        // Only possible for admin to pick up/approv, normal Wikimanager can cancel
+
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(ReviewSubmission $reviewSubmission)
+    {
+        // Possible for admin only
+    }
+}

--- a/app/Http/Controllers/ScheduledSuspensionController.php
+++ b/app/Http/Controllers/ScheduledSuspensionController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\ScheduledSuspension;
+use App\Wiki;
+use Illuminate\Http\Request;
+
+class ScheduledSuspensionController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index()
+    {
+        return ScheduledSuspension::all();
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request)
+    {
+        return ScheduledSuspension::create([
+            'active_from' => $request->input('active_from'),
+            'wiki_id' => $request->input('wiki_id')
+        ]);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show( ScheduledSuspension $suspension )
+    {
+        return $suspension->get();
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, ScheduledSuspension $suspension)
+    {
+        $suspension->first()->update([
+            'active_from' => $request->input('active_from')
+        ]);
+
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(ScheduledSuspension $suspension)
+    {
+        $suspension->first()->delete();
+    }
+
+    public function showByWiki( Wiki $wiki ) {
+        return $wiki->first()->scheduledSuspension;
+    }
+
+}

--- a/app/Jobs/MakeExistingWikisTemporaryJob.php
+++ b/app/Jobs/MakeExistingWikisTemporaryJob.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class MakeExistingWikisTemporaryJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        // Create scheduled suspensions for all Wikis with a reason expiry and a date 3 months from now
+        // unless they already have a scheduledSuspension
+    }
+}

--- a/app/Jobs/NightlyRunScheduledWikiSuspension.php
+++ b/app/Jobs/NightlyRunScheduledWikiSuspension.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Jobs;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+
+class NightlyRunScheduledWikiSuspension implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct()
+    {
+        //
+    }
+
+    /**
+     * Execute the job.
+     */
+    public function handle(): void
+    {
+        // for each Wiki
+        // if it has a scheduledSuspension
+        // and that scheduled suspension
+        // and that should be active by comparison with local time
+        // and there is no submitted or picked-up review review submission
+        // then in a single transaction
+        // create an actual suspension
+        // with an expiry time of now
+        // and the corresponding reason from the scheduled suspension
+        // and remove the scheduled suspension
+    }
+}

--- a/app/ReviewSubmission.php
+++ b/app/ReviewSubmission.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ReviewSubmission extends Model
+{
+    //
+}

--- a/app/ReviewSubmission.php
+++ b/app/ReviewSubmission.php
@@ -3,8 +3,11 @@
 namespace App;
 
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class ReviewSubmission extends Model
 {
-    //
+    public function Wiki(): BelongsTo {
+        return $this->belongsTo(Wiki::class);
+    }
 }

--- a/app/ScheduledSuspension.php
+++ b/app/ScheduledSuspension.php
@@ -2,7 +2,10 @@
 
 namespace App;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class ScheduledSuspension extends Model
 {
@@ -10,4 +13,12 @@ class ScheduledSuspension extends Model
         'active_from',
         'wiki_id'
     ];
+
+    public function Wiki(): BelongsTo {
+        return $this->belongsTo(Wiki::class);
+    }
+
+    public function schedulingDue(): bool {
+        return CarbonImmutable::now() > CarbonImmutable::parse($this->active_from);
+    }
 }

--- a/app/ScheduledSuspension.php
+++ b/app/ScheduledSuspension.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class ScheduledSuspension extends Model
+{
+    protected $fillable = [
+        'active_from',
+        'wiki_id'
+    ];
+}

--- a/app/Wiki.php
+++ b/app/Wiki.php
@@ -109,6 +109,10 @@ class Wiki extends Model {
         return $this->hasMany(WikiSetting::class);
     }
 
+    public function scheduledSuspension(): HasOne {
+        return $this->hasOne(ScheduledSuspension::class);
+    }
+
     public function publicSettings() {
         return $this->settings()->whereIn('name',
             [

--- a/database/migrations/2026_07_31_103148_create_scheduled_suspension_table.php
+++ b/database/migrations/2026_07_31_103148_create_scheduled_suspension_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('scheduled_suspensions', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->foreignId('wiki_id');
+            $table->date('active_from');
+            $table->enum('reason', ['expiry', 'hp_violation', 'tou_violation']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('scheduled_suspension');
+    }
+};

--- a/database/migrations/2026_07_31_103156_create_active_suspension_table.php
+++ b/database/migrations/2026_07_31_103156_create_active_suspension_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('active_suspensions', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->foreignId('wiki_id');
+            $table->date('since');
+            $table->enum('reason', ['expiry', 'hp_violation', 'tou_violation']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('active_suspension');
+    }
+};

--- a/database/migrations/2026_07_31_103206_create_review_submission_table.php
+++ b/database/migrations/2026_07_31_103206_create_review_submission_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('review_submissions', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+            $table->foreignId('wiki_id');
+            $table->enum('status', ['submitted', 'in_review', 'approved', 'rejected', 'cancelled'])->required();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('review_submission');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -65,8 +65,13 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router): v
     $router->get('v1/policies/{policy_type}/upcoming', ['uses' => 'PolicyController@getUpcomingPolicyByType']);
     $router->get('v1/policies/{policy_type}/by_active_from/{active_from}', ['uses' => 'PolicyController@getPolicyByTypeAndActiveFrom']);
     $router->get('v1/policies/{policy_type}', ['uses' => 'PoliciesController@getPoliciesByType']);
+    $router->apiResource('v1/scheduledSuspension', 'ScheduledSuspensionController');
+    $router->apiResource('v1/activeSuspension', 'ActiveSuspensionController')->only('destroy', 'store');
+    $router->apiResource('v1/reviewSubmission', 'ReviewSubmissionController')->only('store', 'update');
+    $router->get('v1/scheduledSuspension/wiki/{wiki}', ['uses' => 'ScheduledSuspensionController@showByWiki']);
 
     $router->apiResource('wiki', 'PublicWikiController')->only(['index', 'show']);
     $router->apiResource('reusePrototype', 'PublicWikiController')->only(['index']);
     $router->apiResource('wikiConversionData', 'ConversionMetricController')->only(['index']);
+
 });

--- a/routes/api.php
+++ b/routes/api.php
@@ -67,7 +67,7 @@ $router->group(['middleware' => ['throttle:45,1']], function () use ($router): v
     $router->get('v1/policies/{policy_type}', ['uses' => 'PoliciesController@getPoliciesByType']);
     $router->apiResource('v1/scheduledSuspension', 'ScheduledSuspensionController');
     $router->apiResource('v1/activeSuspension', 'ActiveSuspensionController')->only('destroy', 'store');
-    $router->apiResource('v1/reviewSubmission', 'ReviewSubmissionController')->only('store', 'update');
+    $router->apiResource('v1/reviewSubmission', 'ReviewSubmissionController');
     $router->get('v1/scheduledSuspension/wiki/{wiki}', ['uses' => 'ScheduledSuspensionController@showByWiki']);
 
     $router->apiResource('wiki', 'PublicWikiController')->only(['index', 'show']);

--- a/tests/Routes/ActiveSuspensionControllerTest.php
+++ b/tests/Routes/ActiveSuspensionControllerTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Tests\Routes;
+
+use App\ActiveSuspension;
+use App\Wiki;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ActiveSuspensionControllerTest extends TestCase {
+    protected $baseRoute = 'v1/activeSuspension';
+
+    private Wiki $wiki;
+
+    use DatabaseTransactions;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->wiki = Wiki::factory()->create();
+    }
+
+    protected function tearDown(): void {
+        parent::tearDown();
+    }
+
+    public function testGetAdminCreateSuspension(): void {
+        $this->json(
+            'POST',
+            $this->baseRoute,
+            $data = [
+                'since' => '2028-01-01',
+                'wiki_id' => $this->wiki->id
+            ]);
+
+        $expectedSuspension = ActiveSuspension::where(
+            [
+                'since' => '2028-01-01',
+                'wiki_id' => $this->wiki->id
+            ]
+        );
+        $this->assertTrue($expectedSuspension->exists());
+    }
+
+    public function testGetAdminRemoveSuspension(): void {
+        $suspension = ActiveSuspension::create([
+            'since' => '2029-01-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+        $suspension2 = ActiveSuspension::create([
+            'since' => '2029-02-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+        $suspension3 = ActiveSuspension::create([
+            'since' => '2029-03-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+        $this->json('DELETE', $this->baseRoute . '/' . $suspension->id )
+        ->assertStatus(200);
+        $this->assertModelMissing($suspension);
+    }
+
+}

--- a/tests/Routes/ReviewSubmissionControllerTest.php
+++ b/tests/Routes/ReviewSubmissionControllerTest.php
@@ -4,7 +4,9 @@ namespace Tests\Routes;
 
 use App\ActiveSuspension;
 use App\ReviewSubmission;
+use App\ScheduledSuspension;
 use App\Wiki;
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 
@@ -20,9 +22,6 @@ class ReviewSubmissionControllerTest extends TestCase {
         $this->wiki = Wiki::factory()->create();
     }
 
-    protected function tearDown(): void {
-        parent::tearDown();
-    }
 
     public function testManagerCreateSubmission(): void {
         $this->json(
@@ -42,11 +41,75 @@ class ReviewSubmissionControllerTest extends TestCase {
     }
 
     public function testManagerCancelSubmission(): void {
+        $submission = $this->createSubmittedSubmission();
+        $this->json(
+            'PUT',
+            $this->baseRoute . '/' . $submission->id,
+            $data = [
+                'wiki_id' => $this->wiki->id,
+                'status' => 'cancelled'
+            ])
+        ->assertStatus(200);
+        $submission->refresh();
+        $this->assertTrue( $submission->status == 'cancelled' );
+    }
 
+    public function testManagerCancelSubmissionActivatesScheduledSuspension(): void {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('first day of October 2023'));
+        $submission = $this->createSubmittedSubmission();
+        $scheduledSupension = ScheduledSuspension::create([
+            'active_from' => '2022-01-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+
+        $this->json(
+            'PUT',
+            $this->baseRoute . '/' . $submission->id,
+            $data = [
+                'wiki_id' => $this->wiki->id,
+                'status' => 'cancelled'
+            ])
+        ->assertStatus(200);
+        $this->assertModelExists(ActiveSuspension::where([
+            'since' => '2023-10-01',
+            'wiki_id' => $this->wiki->id
+            ])->firstorFail());
+        $this->assertModelMissing($scheduledSupension);
+    }
+
+    public function testManagerCancelSubmissionNotActivateScheduledSuspension(): void {
+        CarbonImmutable::setTestNow(CarbonImmutable::parse('first day of October 2023'));
+        $submission = $this->createSubmittedSubmission();
+        $scheduledSupension = ScheduledSuspension::create([
+            'active_from' => '2028-01-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+
+        $this->json(
+            'PUT',
+            $this->baseRoute . '/' . $submission->id,
+            $data = [
+                'wiki_id' => $this->wiki->id,
+                'status' => 'cancelled'
+            ])
+        ->assertStatus(200);
+        $this->assertEquals(0, ActiveSuspension::where([
+            'since' => '2023-10-01',
+            'wiki_id' => $this->wiki->id
+        ])->count());
+        $this->assertModelExists($scheduledSupension);
     }
 
     public function testGetAdminStartPendingReview(): void {
+    }
 
+    private function createSubmittedSubmission(): ReviewSubmission
+    {
+        $submission = new ReviewSubmission();
+        $submission->wiki_id = $this->wiki->id;
+        $submission->status = 'submitted';
+        $submission->save();
+        return $submission;
     }
 
 }

--- a/tests/Routes/ReviewSubmissionControllerTest.php
+++ b/tests/Routes/ReviewSubmissionControllerTest.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Tests\Routes;
+
+use App\ActiveSuspension;
+use App\ReviewSubmission;
+use App\Wiki;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ReviewSubmissionControllerTest extends TestCase {
+    protected $baseRoute = 'v1/reviewSubmission';
+
+    private Wiki $wiki;
+
+    use DatabaseTransactions;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->wiki = Wiki::factory()->create();
+    }
+
+    protected function tearDown(): void {
+        parent::tearDown();
+    }
+
+    public function testManagerCreateSubmission(): void {
+        $this->json(
+            'POST',
+            $this->baseRoute,
+            $data = [
+                'wiki_id' => $this->wiki->id
+            ]);
+
+        $expectedSubmission = ReviewSubmission::where(
+            [
+                'wiki_id' => $this->wiki->id,
+                'status' => 'submitted'
+            ]
+        );
+        $this->assertTrue($expectedSubmission->exists());
+    }
+
+    public function testManagerCancelSubmission(): void {
+
+    }
+
+    public function testGetAdminStartPendingReview(): void {
+
+    }
+
+}

--- a/tests/Routes/ScheduledSuspensions/ScheduledSuspensionControllerTest.php
+++ b/tests/Routes/ScheduledSuspensions/ScheduledSuspensionControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Tests\Routes\ScheduledSuspensions;
+
+use App\ScheduledSuspension;
+use App\Wiki;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\TModel;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+
+class ScheduledSuspensionControllerTest extends TestCase {
+    protected $baseRoute = 'v1/scheduledSuspension';
+
+    private Wiki $wiki;
+
+    use DatabaseTransactions;
+
+    protected function setUp(): void {
+        parent::setUp();
+        $this->wiki = Wiki::factory()->create();
+    }
+
+    protected function tearDown(): void {
+        parent::tearDown();
+    }
+
+    public function testGetEmpty(): void {
+        $this->json('GET', $this->baseRoute )
+        ->assertExactJson([])
+        ->assertStatus(200);
+    }
+
+    public function testGetIndexWithContent(): void {
+        ScheduledSuspension::create([
+                'active_from' => '2028-01-01',
+                'wiki_id' => $this->wiki->id
+            ]);
+        $this->json('GET', $this->baseRoute )
+        ->assertJsonCount(1)
+        ->assertStatus(200);
+    }
+
+    public function testGetAdminCreateSuspension(): void {
+        $this->json(
+            'POST',
+            $this->baseRoute,
+            $data = [
+                'active_from' => '2028-01-01',
+                'wiki_id' => $this->wiki->id
+            ]);
+        $this->assertModelExists(ScheduledSuspension::first());
+    }
+
+    public function testGetSuspensionById(): void {
+        $suspension = ScheduledSuspension::create([
+            'active_from' => '2029-01-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+        $this->json('GET', $this->baseRoute . '/' . $suspension->id )
+        ->assertStatus(200)
+        ->assertJsonFragment(['active_from' => '2029-01-01']);
+    }
+
+    public function testGetAdminUpdateSuspension(): void {
+        $suspension = ScheduledSuspension::create([
+            'active_from' => '2029-01-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+        $this->json('PUT', $this->baseRoute . '/' . $suspension->id, $data = ['active_from' => '2028-01-01'] )
+        ->assertStatus(200);
+        $suspension->refresh();
+        $this->assertEquals( '2028-01-01', $suspension->active_from );
+
+    }
+
+    public function testGetAdminRemoveSuspension(): void {
+        $suspension = ScheduledSuspension::create([
+            'active_from' => '2029-01-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+        $this->json('DELETE', $this->baseRoute . '/' . $suspension->id )
+        ->assertStatus(200);
+        $this->assertModelMissing($suspension);
+    }
+
+    public function testGetActiveSuspensionsByWiki(): void {
+        $suspension = ScheduledSuspension::create([
+            'active_from' => '2029-01-01',
+            'wiki_id' => $this->wiki->id
+        ]);
+        $response = $this->json('GET', $this->baseRoute . '/wiki/' . $this->wiki->id );
+        $response
+        ->assertStatus(200)
+        ->assertJsonFragment(['active_from' => '2029-01-01']);
+    }
+
+
+}


### PR DESCRIPTION
Do not merge, only a prototype for consideration of the architecture of the implmentation plan proposed by the PM

Still to be done:
 - implementation ReviewSubmission controller
 - MakeExistingWikisTemporaryJob
 - NightlyRunScheduledWikiSuspensionJobs